### PR TITLE
fix: reorder sections in Navbar and update prop names for clarity

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,12 +69,12 @@ function App() {
     );
   }
 
-  // Define sections for Navbar
+  // Define sections for Navbar in the order: home, about, development, music, contact
   const sections = [
     { id: 'home', label: 'Home' },
-    { id: 'music', label: 'Music' },
-    { id: 'development', label: 'Development' },
     { id: 'about', label: 'About' },
+    { id: 'development', label: 'Development' },
+    { id: 'music', label: 'Music' },
     { id: 'contact', label: 'Contact' },
   ];
 
@@ -86,7 +86,7 @@ function App() {
           Skip to Music content
         </a>
         <Navbar
-          sections={sections}
+          orderedSections={sections}
           activeSection={activeSection}
           setActiveSection={navigateToSection}
         />
@@ -95,17 +95,17 @@ function App() {
           <section id="home" className="section-container relative min-h-[110vh] pb-24 md:pb-32 bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
             <HomeSection onNavigateToSection={navigateToSection} />
           </section>
-
-          <section id="music" className="section-container relative min-h-[110vh] pb-24 md:pb-32 bg-gradient-to-br from-purple-900 via-blue-900 to-indigo-900">
-            <MusicSection />
+          
+          <section id="about" className="section-container relative min-h-[110vh] pb-24 md:pb-32 bg-gradient-to-br from-slate-900 via-gray-900 to-slate-900">
+            <AboutSection />
           </section>
 
           <section id="development" className="section-container relative min-h-[110vh] pb-24 md:pb-32 bg-gradient-to-br from-emerald-900 via-teal-900 to-cyan-900">
             <DevelopmentSection />
           </section>
 
-          <section id="about" className="section-container relative min-h-[110vh] pb-24 md:pb-32 bg-gradient-to-br from-slate-900 via-gray-900 to-slate-900">
-            <AboutSection />
+          <section id="music" className="section-container relative min-h-[110vh] pb-24 md:pb-32 bg-gradient-to-br from-purple-900 via-blue-900 to-indigo-900">
+            <MusicSection />
           </section>
 
           <section id="contact" className="section-container relative min-h-[110vh] pb-24 md:pb-32 bg-gradient-to-br from-indigo-900 via-purple-900 to-pink-900">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,9 +4,9 @@ import React, { useRef, useEffect } from 'react';
 import { useMobileNavigation, useNavbarScroll } from '../hooks';
 import {
   LuHouse,
-  LuMusic,
-  LuCode,
   LuUser,
+  LuCode,
+  LuMusic,
   LuMail,
   LuMenu,
   LuX
@@ -19,12 +19,12 @@ interface Section {
 }
 
 interface NavbarProps {
-  sections: Section[];
+  orderedSections: Section[];
   activeSection: string;
   setActiveSection: (section: string) => void;
 }
 
-function Navbar({ sections, activeSection, setActiveSection }: NavbarProps) {
+function Navbar({ orderedSections, activeSection, setActiveSection }: NavbarProps) {
   const navRef = useRef<HTMLElement>(null);
   const brandRef = useRef<HTMLButtonElement>(null);
   const {
@@ -90,8 +90,15 @@ function Navbar({ sections, activeSection, setActiveSection }: NavbarProps) {
     };
   }, []);
 
+  // Only allow navigation to known section IDs
   const handleNavClick = (sectionId: string) => {
-    setActiveSection(sectionId);
+    const validSection = orderedSections.find(section => section.id === sectionId);
+    if (validSection) {
+      setActiveSection(sectionId);
+    } else {
+      // Optionally, log or handle invalid navigation attempts
+      console.warn(`Attempted navigation to invalid section: ${sectionId}`);
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent, sectionId: string) => {
@@ -101,12 +108,14 @@ function Navbar({ sections, activeSection, setActiveSection }: NavbarProps) {
     }
   };
 
+  // orderedSections is passed as a prop, do not redeclare it here
+
   const getSectionIcon = (sectionId: string) => {
     const icons: Record<string, React.ComponentType<{ className?: string }>> = {
       home: LuHouse,
-      music: LuMusic,
-      development: LuCode,
       about: LuUser,
+      development: LuCode,
+      music: LuMusic,
       contact: LuMail,
     };
     return icons[sectionId] || LuHouse;
@@ -124,134 +133,130 @@ function Navbar({ sections, activeSection, setActiveSection }: NavbarProps) {
         role="navigation"
         aria-label="Main navigation"
       >
-      <div className="flex-1 flex items-center min-w-0">
-        <button
-          ref={brandRef}
-          className="font-mono text-xl font-bold tracking-wide uppercase text-white hover:text-indigo-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 rounded-lg px-2 py-1 flex-shrink-0"
-          onClick={() => setActiveSection('home')}
-          aria-label="Navigate to home section"
-        >
-          <span className="gradient-text">KEVIN</span>
-          <br />
-          <span className="gradient-text">HENDERSON</span>
-        </button>
-      </div>
-
-      {/* Mobile Hamburger Button */}
-      {isMobile && (
-        <button
-          ref={hamburgerRef}
-          className={`relative flex flex-col justify-center items-center w-12 h-12 min-w-[48px] min-h-[48px] rounded-xl z-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 ${
-            isMobileMenuOpen
-              ? 'glass-effect bg-white/20 shadow-lg'
-              : 'hover:bg-white/10 hover:backdrop-blur-sm'
-          }`}
-          onClick={toggleMobileMenu}
-          aria-expanded={isMobileMenuOpen}
-          aria-controls="mobile-menu"
-          aria-label={isMobileMenuOpen ? 'Close navigation menu' : 'Open navigation menu'}
-          type="button"
-        >
-          {isMobileMenuOpen ? (
-            <LuX className="w-6 h-6 text-white rotate-0" />
-          ) : (
-            <LuMenu className="w-6 h-6 text-white" />
-          )}
-        </button>
-      )}
-
-      {/* Desktop Navigation */}
-      {!isMobile && (
-        <div className="flex flex-row items-center gap-3 flex-shrink-0 max-w-full overflow-hidden">
-          <div className="flex flex-row gap-2 flex-wrap">
-            {sections.map(section => (
-              <button
-                key={section.id}
-                className={`group flex items-center gap-2 px-3 py-2 min-h-[44px] rounded-xl font-medium text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 whitespace-nowrap ${
-                  activeSection === section.id
-                    ? 'glass-effect bg-indigo-600/80 text-white shadow-lg backdrop-blur-sm border border-indigo-400/30'
-                    : 'text-gray-300 hover:text-white hover:bg-white/10 hover:backdrop-blur-sm'
-                }`}
-                onClick={() => setActiveSection(section.id)}
-                aria-current={activeSection === section.id ? 'page' : undefined}
-                tabIndex={0}
-              >
-                {React.createElement(getSectionIcon(section.id), {
-                  className: `w-4 h-4 ${
-                    activeSection === section.id ? 'text-white' : ''
-                  }`
-                })}
-                <span className="uppercase tracking-wide font-semibold text-sm">{section.label}</span>
-              </button>
-            ))}
-          </div>
-          {/* Theme toggle removed; app is locked to dark theme */}
+        <div className="flex-1 flex items-center min-w-0">
+          <button
+            ref={brandRef}
+            className="font-mono text-xl font-bold tracking-wide uppercase text-white hover:text-indigo-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 rounded-lg px-2 py-1 flex-shrink-0"
+            onClick={() => setActiveSection('home')}
+            aria-label="Navigate to home section"
+          >
+            <span className="gradient-text">KEVIN</span>
+            <br />
+            <span className="gradient-text">HENDERSON</span>
+          </button>
         </div>
-      )}
 
-    </nav>
+        {/* Mobile Hamburger Button */}
+        {isMobile && (
+          <button
+            ref={hamburgerRef}
+            className={`relative flex flex-col justify-center items-center w-12 h-12 min-w-[48px] min-h-[48px] rounded-xl z-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 ${
+              isMobileMenuOpen
+                ? 'glass-effect bg-white/20 shadow-lg'
+                : 'hover:bg-white/10 hover:backdrop-blur-sm'
+            }`}
+            onClick={toggleMobileMenu}
+            aria-expanded={isMobileMenuOpen}
+            aria-controls="mobile-menu"
+            aria-label={isMobileMenuOpen ? 'Close navigation menu' : 'Open navigation menu'}
+            type="button"
+          >
+            {isMobileMenuOpen ? (
+              <LuX className="w-6 h-6 text-white rotate-0" />
+            ) : (
+              <LuMenu className="w-6 h-6 text-white" />
+            )}
+          </button>
+        )}
 
-    {/* Mobile Menu Overlay */}
-    {isMobile && (
-      <div
-        className={`mobile-menu-overlay fixed inset-0 bg-black/80 backdrop-blur-md z-40 ${isMobileMenuOpen ? 'open' : ''}`}
-        aria-hidden="true"
-        onClick={closeMobileMenu}
-      />
-    )}
-
-    {/* Mobile Menu */}
-    {isMobile && (
-      <div
-        ref={mobileMenuRef}
-        id="mobile-menu"
-        className={`mobile-menu ${isMobileMenuOpen ? 'open' : ''} fixed top-0 right-0 h-screen w-[min(320px,85vw)] glass-effect border-l border-white/20 shadow-2xl z-50 overflow-y-auto overflow-x-hidden backdrop-blur-2xl`}
-        role="menu"
-        aria-labelledby="hamburger-button"
-      >
-        <div className="mobile-menu-content flex flex-col h-full">
-          {/* Mobile Menu Header */}
-          <div className="flex items-center justify-between p-6 border-b border-white/10">
-            <div className="font-mono text-lg font-bold tracking-wide uppercase text-white">
-              <span className="gradient-text">Menu</span>
+        {/* Desktop Navigation */}
+        {!isMobile && (
+          <div className="flex flex-row items-center gap-3 flex-shrink-0 max-w-full overflow-hidden">
+            <div className="flex flex-row gap-2 flex-wrap">
+              {orderedSections.map(section => (
+                <button
+                  key={section.id}
+                  className={`group flex items-center gap-2 px-3 py-2 min-h-[44px] rounded-xl font-medium text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 whitespace-nowrap ${
+                    activeSection === section.id
+                      ? 'glass-effect bg-indigo-600/80 text-white shadow-lg backdrop-blur-sm border border-indigo-400/30'
+                      : 'text-gray-300 hover:text-white hover:bg-white/10 hover:backdrop-blur-sm'
+                  }`}
+                  onClick={() => setActiveSection(section.id)}
+                  aria-current={activeSection === section.id ? 'page' : undefined}
+                  tabIndex={0}
+                >
+                  {React.createElement(getSectionIcon(section.id), {
+                    className: `w-4 h-4 ${
+                      activeSection === section.id ? 'text-white' : ''
+                    }`
+                  })}
+                  <span className="uppercase tracking-wide font-semibold text-sm">{section.label}</span>
+                </button>
+              ))}
             </div>
-            <button
-              className="flex items-center justify-center w-10 h-10 rounded-lg text-white hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
-              onClick={closeMobileMenu}
-              aria-label="Close navigation menu"
-            >
-              <LuX className="w-6 h-6" />
-            </button>
           </div>
+        )}
 
-          {/* Mobile Menu Content */}
-          <div className="mobile-nav-links flex-1 py-4">
-            {sections.map((section, index) => (
+      </nav>
+
+      {/* Mobile Menu Overlay */}
+      {isMobile && (
+        <div
+          className={`mobile-menu-overlay fixed inset-0 bg-black/80 backdrop-blur-md z-40 ${isMobileMenuOpen ? 'open' : ''}`}
+          aria-hidden="true"
+          onClick={closeMobileMenu}
+        />
+      )}
+
+      {/* Mobile Menu */}
+      {isMobile && (
+        <div
+          ref={mobileMenuRef}
+          id="mobile-menu"
+          className={`mobile-menu ${isMobileMenuOpen ? 'open' : ''} fixed top-0 right-0 h-screen w-[min(320px,85vw)] glass-effect border-l border-white/20 shadow-2xl z-50 overflow-y-auto overflow-x-hidden backdrop-blur-2xl`}
+          role="menu"
+          aria-labelledby="hamburger-button"
+        >
+          <div className="mobile-menu-content flex flex-col h-full">
+            {/* Mobile Menu Header */}
+            <div className="flex items-center justify-between p-6 border-b border-white/10">
+              <div className="font-mono text-lg font-bold tracking-wide uppercase text-white">
+                <span className="gradient-text">Menu</span>
+              </div>
               <button
-                key={section.id}
-                className={`mobile-nav-link flex items-center gap-4 w-full px-6 py-4 font-medium text-left cursor-pointer border-l-4 border-transparent min-h-[3.5rem] focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 text-white ${
-                  activeSection === section.id
-                    ? 'bg-indigo-600/20 text-indigo-300 border-l-indigo-400 font-semibold backdrop-blur-sm'
-                    : 'hover:bg-white/10 hover:text-indigo-300 hover:border-l-white/30 hover:backdrop-blur-sm'
-                }`}
-                onClick={() => handleNavClick(section.id)}
-                onKeyDown={(e) => handleKeyDown(e, section.id)}
-                role="menuitem"
-                tabIndex={isMobileMenuOpen ? 0 : -1}
-                aria-current={activeSection === section.id ? 'page' : undefined}
-                style={{ '--animation-delay': `${index * 0.12}s` } as React.CSSProperties}
+                className="flex items-center justify-center w-10 h-10 rounded-lg text-white hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                onClick={closeMobileMenu}
+                aria-label="Close navigation menu"
               >
-                {React.createElement(getSectionIcon(section.id), { className: "w-6 h-6 mobile-nav-icon" })}
-                <span className="flex-1 uppercase tracking-wide text-base">{section.label}</span>
+                <LuX className="w-6 h-6" />
               </button>
-            ))}
-          </div>
+            </div>
 
-          {/* Mobile Menu Footer */}
-          {/* Theme toggle removed from mobile menu; app is locked to dark theme */}
+            {/* Mobile Menu Content */}
+            <div className="mobile-nav-links flex-1 py-4">
+              {orderedSections.map((section, index) => (
+                <button
+                  key={section.id}
+                  className={`mobile-nav-link flex items-center gap-4 w-full px-6 py-4 font-medium text-left cursor-pointer border-l-4 border-transparent min-h-[3.5rem] focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 text-white ${
+                    activeSection === section.id
+                      ? 'bg-indigo-600/20 text-indigo-300 border-l-indigo-400 font-semibold backdrop-blur-sm'
+                      : 'hover:bg-white/10 hover:text-indigo-300 hover:border-l-white/30 hover:backdrop-blur-sm'
+                  }`}
+                  onClick={() => handleNavClick(section.id)}
+                  onKeyDown={(e) => handleKeyDown(e, section.id)}
+                  role="menuitem"
+                  tabIndex={isMobileMenuOpen ? 0 : -1}
+                  aria-current={activeSection === section.id ? 'page' : undefined}
+                  style={{ '--animation-delay': `${index * 0.12}s` } as React.CSSProperties}
+                >
+                  {React.createElement(getSectionIcon(section.id), { className: "w-6 h-6 mobile-nav-icon" })}
+                  <span className="flex-1 uppercase tracking-wide text-base">{section.label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
         </div>
-      </div>
-    )}
+      )}
     </>
   );
 }


### PR DESCRIPTION
This pull request reorganizes the order of sections in the navigation bar and corresponding page sections to improve consistency and user experience. It also refactors the `Navbar` component to use a more clearly named prop (`orderedSections`) and adds validation to navigation actions. The most important changes are:

**Navigation and Section Order:**

* The order of sections in both the navigation bar and the main content was updated to: Home, About, Development, Music, Contact, ensuring the navigation matches the page layout. (`src/App.tsx`) [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L72-R77) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L99-R108)

**Component API and Prop Naming:**

* The `Navbar` component now expects an `orderedSections` prop instead of `sections`, and all relevant usages have been updated for clarity. (`src/App.tsx`, `src/components/Navbar.tsx`) [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L89-R89) [[2]](diffhunk://#diff-a0439d8a2cb6dee715c41a795bb174a2a65ad61704e88691fe5ab2b2bd6f798eL22-R27) [[3]](diffhunk://#diff-a0439d8a2cb6dee715c41a795bb174a2a65ad61704e88691fe5ab2b2bd6f798eL167-R176) [[4]](diffhunk://#diff-a0439d8a2cb6dee715c41a795bb174a2a65ad61704e88691fe5ab2b2bd6f798eL229-R237)

**Navigation Logic and Validation:**

* Navigation clicks are now validated to ensure only known section IDs are navigated to, with warnings logged for invalid attempts. (`src/components/Navbar.tsx`)

**Icon and Import Order Consistency:**

* The order of icon imports and their mapping to sections was updated to match the new section order, improving code readability and maintainability. (`src/components/Navbar.tsx`) [[1]](diffhunk://#diff-a0439d8a2cb6dee715c41a795bb174a2a65ad61704e88691fe5ab2b2bd6f798eL7-R9) [[2]](diffhunk://#diff-a0439d8a2cb6dee715c41a795bb174a2a65ad61704e88691fe5ab2b2bd6f798eR111-R118)

**Code Cleanup:**

* Removed commented-out theme toggle code, reflecting that the app is now locked to dark mode. (`src/components/Navbar.tsx`) [[1]](diffhunk://#diff-a0439d8a2cb6dee715c41a795bb174a2a65ad61704e88691fe5ab2b2bd6f798eL188) [[2]](diffhunk://#diff-a0439d8a2cb6dee715c41a795bb174a2a65ad61704e88691fe5ab2b2bd6f798eL249-L251)