### PR TITLE
Potential fix for code scanning alert no. 2: Replacement of a substring with itself

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -13,7 +13,6 @@ function ProjectCard({ project }: ProjectCardProps) {
       .replace(/\s+/g, '')
       .replace(/[^a-z0-9]/g, '')
       .replace('javascript', 'javascript')
-      .replace('typescript', 'typescript')
       .replace('nodejs', 'node')
       .replace('reactjs', 'react')
       .replace('vuejs', 'vue')


### PR DESCRIPTION
Potential fix for [https://github.com/khenderson20/kevin-portfolio/security/code-scanning/2](https://github.com/khenderson20/kevin-portfolio/security/code-scanning/2)

To fix the issue, you should remove the redundant substring replacement:
```ts
.replace('typescript', 'typescript')
```
from the `normalizeTechName` helper function within `ProjectCard`. No actual transformation is accomplished by this line, so removing it will have no effect on output but will eliminate confusion and potential maintenance overhead. No additional changes, imports, or dependencies are needed as a result of this removal.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
