### PR TITLE
Potential fix for code scanning alert no. 3: Replacement of a substring with itself

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -12,7 +12,6 @@ function ProjectCard({ project }: ProjectCardProps) {
     return tech.toLowerCase()
       .replace(/\s+/g, '')
       .replace(/[^a-z0-9]/g, '')
-      .replace('javascript', 'javascript')
       .replace('nodejs', 'node')
       .replace('reactjs', 'react')
       .replace('vuejs', 'vue')


### PR DESCRIPTION
Potential fix for [https://github.com/khenderson20/kevin-portfolio/security/code-scanning/3](https://github.com/khenderson20/kevin-portfolio/security/code-scanning/3)

The best fix is to remove the unnecessary replacement `.replace('javascript', 'javascript')` since it has no effect. Review whether a mapping for "js" or similar substrings is actually intended (e.g., mapping "js" → "javascript" for canonicalization), but based strictly on the lines provided and the pattern of other replacements, the fix is to delete line 15 (the self-replacement). No new methods or imports are required; just remove the redundant line within the `normalizeTechName` function in src/components/ProjectCard.tsx.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
