### PR TITLE
feat(ui): redesign sections with retro theme and add tech filtering

### DIFF
--- a/public/cookies.html
+++ b/public/cookies.html
@@ -1,0 +1,388 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cookie Policy - Kevin Henderson</title>
+  <meta name="description" content="Cookie Policy for Kevin Henderson's portfolio website. Learn how we use cookies and how to manage your preferences.">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  
+  <!-- Font preconnect -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  
+  <!-- Theme -->
+  <meta name="theme-color" content="#0ea5e9">
+  <meta name="color-scheme" content="dark">
+  
+  <style>
+    *, *::before, *::after {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+    
+    html {
+      scroll-behavior: smooth;
+    }
+    
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: linear-gradient(to bottom right, #020617, #111827, #020617);
+      color: #d1d5db;
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+    
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+    
+    /* Header */
+    header {
+      padding: 2rem 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+      margin-bottom: 3rem;
+    }
+    
+    .back-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: #60a5fa;
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: color 0.2s ease;
+      margin-bottom: 1.5rem;
+    }
+    
+    .back-link:hover {
+      color: #93c5fd;
+    }
+    
+    .back-link svg {
+      width: 1rem;
+      height: 1rem;
+    }
+    
+    h1 {
+      font-size: clamp(2rem, 5vw, 2.5rem);
+      font-weight: 700;
+      color: white;
+      margin-bottom: 0.5rem;
+      background: linear-gradient(135deg, #7dd3fc, #10b981);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    
+    .last-updated {
+      font-size: 0.875rem;
+      color: #9ca3af;
+    }
+    
+    /* Main content */
+    main {
+      padding-bottom: 4rem;
+    }
+    
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: white;
+      margin-top: 2.5rem;
+      margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    }
+    
+    h3 {
+      font-size: 1.125rem;
+      font-weight: 600;
+      color: #e5e7eb;
+      margin-top: 1.5rem;
+      margin-bottom: 0.75rem;
+    }
+    
+    p {
+      margin-bottom: 1rem;
+    }
+    
+    ul {
+      margin-bottom: 1rem;
+      padding-left: 1.5rem;
+    }
+    
+    li {
+      margin-bottom: 0.5rem;
+    }
+    
+    a {
+      color: #60a5fa;
+      text-decoration: none;
+      transition: color 0.2s ease;
+    }
+    
+    a:hover {
+      color: #93c5fd;
+    }
+    
+    .highlight-box {
+      background: rgba(14, 165, 233, 0.1);
+      border: 1px solid rgba(14, 165, 233, 0.2);
+      border-radius: 0.5rem;
+      padding: 1rem 1.5rem;
+      margin: 1.5rem 0;
+    }
+    
+    .cookie-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1.5rem 0;
+      font-size: 0.875rem;
+    }
+    
+    .cookie-table th,
+    .cookie-table td {
+      text-align: left;
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    }
+    
+    .cookie-table th {
+      background: rgba(255, 255, 255, 0.05);
+      color: white;
+      font-weight: 600;
+    }
+    
+    .cookie-table tr:hover {
+      background: rgba(255, 255, 255, 0.02);
+    }
+    
+    .badge {
+      display: inline-block;
+      padding: 0.25rem 0.5rem;
+      border-radius: 0.25rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+    }
+    
+    .badge-essential {
+      background: rgba(16, 185, 129, 0.2);
+      color: #34d399;
+    }
+    
+    .badge-analytics {
+      background: rgba(59, 130, 246, 0.2);
+      color: #60a5fa;
+    }
+    
+    /* Footer */
+    footer {
+      border-top: 1px solid rgba(255, 255, 255, 0.1);
+      padding: 2rem 0;
+      margin-top: 3rem;
+    }
+    
+    .footer-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    
+    .footer-links a {
+      font-size: 0.875rem;
+      color: #9ca3af;
+    }
+    
+    .footer-links a:hover {
+      color: white;
+    }
+    
+    .copyright {
+      font-size: 0.75rem;
+      color: #6b7280;
+    }
+    
+    .copyright .name {
+      font-weight: 600;
+      background: linear-gradient(135deg, #7dd3fc, #10b981);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    
+    /* Responsive */
+    @media (max-width: 640px) {
+      .container {
+        padding: 1.5rem 1rem;
+      }
+      
+      h1 {
+        font-size: 1.75rem;
+      }
+      
+      h2 {
+        font-size: 1.25rem;
+      }
+      
+      .footer-links {
+        flex-direction: column;
+        gap: 1rem;
+      }
+      
+      .cookie-table {
+        display: block;
+        overflow-x: auto;
+      }
+      
+      .cookie-table th,
+      .cookie-table td {
+        padding: 0.5rem;
+        font-size: 0.75rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <a href="/" class="back-link">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+        </svg>
+        Back to Portfolio
+      </a>
+      <h1>Cookie Policy</h1>
+      <p class="last-updated">Last updated: January 25, 2026</p>
+    </header>
+    
+    <main>
+      <section>
+        <h2>What Are Cookies</h2>
+        <p>Cookies are small text files that are stored on your device (computer, tablet, or mobile) when you visit a website. They are widely used to make websites work more efficiently and provide information to website owners.</p>
+        <p>Cookies can be "persistent" (remaining on your device until deleted) or "session" cookies (deleted when you close your browser).</p>
+      </section>
+      
+      <section>
+        <h2>How We Use Cookies</h2>
+        <p>Kevin Henderson's portfolio website uses a minimal number of cookies to ensure the site functions properly and to understand how visitors interact with the content.</p>
+        
+        <div class="highlight-box">
+          <p><strong>Our approach to cookies:</strong> We believe in minimal data collection. This website uses only essential and basic analytics cookies, and does not use advertising or tracking cookies.</p>
+        </div>
+        
+        <h3>Essential Cookies</h3>
+        <p>These cookies are necessary for the website to function properly. They enable basic features like page navigation and access to secure areas. The website cannot function properly without these cookies.</p>
+        
+        <h3>Analytics Cookies</h3>
+        <p>These cookies help us understand how visitors interact with the website by collecting and reporting information anonymously. This helps us improve the website's performance and user experience.</p>
+      </section>
+      
+      <section>
+        <h2>Cookies We Use</h2>
+        <table class="cookie-table">
+          <thead>
+            <tr>
+              <th>Cookie Name</th>
+              <th>Type</th>
+              <th>Purpose</th>
+              <th>Duration</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>__cfduid</td>
+              <td><span class="badge badge-essential">Essential</span></td>
+              <td>Cloudflare security cookie for trusted web traffic</td>
+              <td>30 days</td>
+            </tr>
+            <tr>
+              <td>_ga</td>
+              <td><span class="badge badge-analytics">Analytics</span></td>
+              <td>Google Analytics - distinguishes unique users</td>
+              <td>2 years</td>
+            </tr>
+            <tr>
+              <td>_gid</td>
+              <td><span class="badge badge-analytics">Analytics</span></td>
+              <td>Google Analytics - distinguishes unique users</td>
+              <td>24 hours</td>
+            </tr>
+            <tr>
+              <td>_gat</td>
+              <td><span class="badge badge-analytics">Analytics</span></td>
+              <td>Google Analytics - throttles request rate</td>
+              <td>1 minute</td>
+            </tr>
+          </tbody>
+        </table>
+        <p><em>Note: The specific cookies may vary based on your region and our current analytics configuration. This table represents typical cookies that may be set.</em></p>
+      </section>
+      
+      <section>
+        <h2>Third-Party Cookies</h2>
+        <p>This website may set cookies from third-party services including:</p>
+        
+        <h3>Netlify</h3>
+        <p>Our hosting provider may set cookies for security, performance optimization, and load balancing purposes. For more information, see <a href="https://www.netlify.com/privacy/" target="_blank" rel="noopener noreferrer">Netlify's Privacy Policy</a>.</p>
+        
+        <h3>Google Analytics</h3>
+        <p>We may use Google Analytics to understand website traffic and usage patterns. Google Analytics uses cookies to collect information about your use of the website, which is transmitted to and stored by Google. For more information, see <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Google's Privacy Policy</a>.</p>
+        
+        <h3>Embedded Content</h3>
+        <p>Some pages may include embedded content (e.g., Spotify players, GitHub badges) from third-party websites. These embeds may set their own cookies. We do not control these cookies and recommend reviewing the privacy policies of these services.</p>
+      </section>
+      
+      <section>
+        <h2>Managing Cookies</h2>
+        <p>You have the right to decide whether to accept or reject cookies. You can manage your cookie preferences in several ways:</p>
+        
+        <h3>Browser Settings</h3>
+        <p>Most web browsers allow you to control cookies through their settings. You can typically find these settings in the "Options" or "Preferences" menu of your browser. The following links provide instructions for common browsers:</p>
+        <ul>
+          <li><a href="https://support.google.com/chrome/answer/95647" target="_blank" rel="noopener noreferrer">Google Chrome</a></li>
+          <li><a href="https://support.mozilla.org/en-US/kb/cookies-information-websites-store-on-your-computer" target="_blank" rel="noopener noreferrer">Mozilla Firefox</a></li>
+          <li><a href="https://support.apple.com/guide/safari/manage-cookies-and-website-data-sfri11471/mac" target="_blank" rel="noopener noreferrer">Safari</a></li>
+          <li><a href="https://support.microsoft.com/en-us/microsoft-edge/delete-cookies-in-microsoft-edge-63947406-40ac-c3b8-57b9-2a946a29ae09" target="_blank" rel="noopener noreferrer">Microsoft Edge</a></li>
+        </ul>
+        
+        <h3>Opt-Out of Analytics</h3>
+        <p>You can opt out of Google Analytics by installing the <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer">Google Analytics Opt-out Browser Add-on</a>.</p>
+        
+        <h3>Do Not Track</h3>
+        <p>Some browsers include a "Do Not Track" feature that signals to websites that you do not want your online activity tracked. This website respects Do Not Track signals when possible.</p>
+        
+        <div class="highlight-box">
+          <p><strong>Note:</strong> Disabling certain cookies may affect the functionality of this website. Essential cookies cannot be disabled as they are necessary for the website to work properly.</p>
+        </div>
+      </section>
+      
+      <section>
+        <h2>Changes to This Policy</h2>
+        <p>This Cookie Policy may be updated from time to time to reflect changes in our practices or for other operational, legal, or regulatory reasons. Any changes will be posted on this page with an updated revision date.</p>
+      </section>
+      
+      <section>
+        <h2>Contact Information</h2>
+        <p>If you have any questions about our use of cookies or this Cookie Policy, please contact me through the contact form on the main website or via the social links provided in the footer.</p>
+      </section>
+    </main>
+    
+    <footer>
+      <nav class="footer-links">
+        <a href="/privacy">Privacy Policy</a>
+        <a href="/terms">Terms of Service</a>
+        <a href="/cookies">Cookie Policy</a>
+        <a href="/">Back to Portfolio</a>
+      </nav>
+      <p class="copyright">© 2026 <span class="name">Kevin Henderson</span>. All rights reserved.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy - Kevin Henderson</title>
+  <meta name="description" content="Privacy Policy for Kevin Henderson's portfolio website. Learn how we handle your data and protect your privacy.">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  
+  <!-- Font preconnect -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  
+  <!-- Theme -->
+  <meta name="theme-color" content="#0ea5e9">
+  <meta name="color-scheme" content="dark">
+  
+  <style>
+    *, *::before, *::after {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+    
+    html {
+      scroll-behavior: smooth;
+    }
+    
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: linear-gradient(to bottom right, #020617, #111827, #020617);
+      color: #d1d5db;
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+    
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+    
+    /* Header */
+    header {
+      padding: 2rem 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+      margin-bottom: 3rem;
+    }
+    
+    .back-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: #60a5fa;
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: color 0.2s ease;
+      margin-bottom: 1.5rem;
+    }
+    
+    .back-link:hover {
+      color: #93c5fd;
+    }
+    
+    .back-link svg {
+      width: 1rem;
+      height: 1rem;
+    }
+    
+    h1 {
+      font-size: clamp(2rem, 5vw, 2.5rem);
+      font-weight: 700;
+      color: white;
+      margin-bottom: 0.5rem;
+      background: linear-gradient(135deg, #7dd3fc, #10b981);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    
+    .last-updated {
+      font-size: 0.875rem;
+      color: #9ca3af;
+    }
+    
+    /* Main content */
+    main {
+      padding-bottom: 4rem;
+    }
+    
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: white;
+      margin-top: 2.5rem;
+      margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    }
+    
+    h3 {
+      font-size: 1.125rem;
+      font-weight: 600;
+      color: #e5e7eb;
+      margin-top: 1.5rem;
+      margin-bottom: 0.75rem;
+    }
+    
+    p {
+      margin-bottom: 1rem;
+    }
+    
+    ul {
+      margin-bottom: 1rem;
+      padding-left: 1.5rem;
+    }
+    
+    li {
+      margin-bottom: 0.5rem;
+    }
+    
+    a {
+      color: #60a5fa;
+      text-decoration: none;
+      transition: color 0.2s ease;
+    }
+    
+    a:hover {
+      color: #93c5fd;
+    }
+    
+    .highlight-box {
+      background: rgba(14, 165, 233, 0.1);
+      border: 1px solid rgba(14, 165, 233, 0.2);
+      border-radius: 0.5rem;
+      padding: 1rem 1.5rem;
+      margin: 1.5rem 0;
+    }
+    
+    /* Footer */
+    footer {
+      border-top: 1px solid rgba(255, 255, 255, 0.1);
+      padding: 2rem 0;
+      margin-top: 3rem;
+    }
+    
+    .footer-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    
+    .footer-links a {
+      font-size: 0.875rem;
+      color: #9ca3af;
+    }
+    
+    .footer-links a:hover {
+      color: white;
+    }
+    
+    .copyright {
+      font-size: 0.75rem;
+      color: #6b7280;
+    }
+    
+    .copyright .name {
+      font-weight: 600;
+      background: linear-gradient(135deg, #7dd3fc, #10b981);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    
+    /* Responsive */
+    @media (max-width: 640px) {
+      .container {
+        padding: 1.5rem 1rem;
+      }
+      
+      h1 {
+        font-size: 1.75rem;
+      }
+      
+      h2 {
+        font-size: 1.25rem;
+      }
+      
+      .footer-links {
+        flex-direction: column;
+        gap: 1rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <a href="/" class="back-link">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+        </svg>
+        Back to Portfolio
+      </a>
+      <h1>Privacy Policy</h1>
+      <p class="last-updated">Last updated: January 25, 2026</p>
+    </header>
+    
+    <main>
+      <section>
+        <h2>Introduction</h2>
+        <p>Welcome to Kevin Henderson's portfolio website ("the Website"). I respect your privacy and am committed to protecting any information that may be collected while you browse this site.</p>
+        <p>This Privacy Policy explains what information may be collected, how it's used, and your rights regarding that information. This policy applies to all visitors of kevinhenderson.dev.</p>
+      </section>
+      
+      <section>
+        <h2>Information We Collect</h2>
+        
+        <h3>Automatically Collected Information</h3>
+        <p>When you visit the Website, certain information may be automatically collected through basic analytics, including:</p>
+        <ul>
+          <li>Browser type and version</li>
+          <li>Operating system</li>
+          <li>Referring website (if applicable)</li>
+          <li>Pages visited and time spent on the site</li>
+          <li>General geographic location (country/region level)</li>
+        </ul>
+        
+        <h3>Information We Do Not Collect</h3>
+        <div class="highlight-box">
+          <p><strong>This website does not:</strong></p>
+          <ul>
+            <li>Collect personal identification information through forms</li>
+            <li>Store any contact form submissions on our servers</li>
+            <li>Require user registration or accounts</li>
+            <li>Track individual users across sessions</li>
+          </ul>
+        </div>
+      </section>
+      
+      <section>
+        <h2>How We Use Information</h2>
+        <p>The limited information collected is used solely for:</p>
+        <ul>
+          <li><strong>Website Improvement:</strong> Understanding how visitors interact with the site to improve user experience</li>
+          <li><strong>Traffic Analysis:</strong> Monitoring overall traffic patterns and popular content</li>
+          <li><strong>Technical Optimization:</strong> Ensuring the website performs well across different devices and browsers</li>
+        </ul>
+      </section>
+      
+      <section>
+        <h2>Third-Party Services</h2>
+        <p>This website uses the following third-party services:</p>
+        
+        <h3>Netlify (Hosting)</h3>
+        <p>The Website is hosted on Netlify, which may collect basic server logs including IP addresses for security and performance purposes. For more information, see <a href="https://www.netlify.com/privacy/" target="_blank" rel="noopener noreferrer">Netlify's Privacy Policy</a>.</p>
+        
+        <h3>Analytics</h3>
+        <p>Basic analytics may be used to understand website traffic. These analytics are configured to minimize data collection and do not track individual users or store personal information.</p>
+      </section>
+      
+      <section>
+        <h2>Your Rights</h2>
+        <p>You have the right to:</p>
+        <ul>
+          <li><strong>Access Information:</strong> Request details about any data associated with your visit</li>
+          <li><strong>Opt-Out:</strong> Disable cookies through your browser settings to limit data collection</li>
+          <li><strong>Request Deletion:</strong> Ask for removal of any data that may be associated with you</li>
+        </ul>
+        <p>Since this website collects minimal data and does not store personal information, there is typically no personal data to access or delete.</p>
+      </section>
+      
+      <section>
+        <h2>Data Security</h2>
+        <p>While no method of transmission over the Internet is 100% secure, reasonable measures are taken to protect any information collected, including:</p>
+        <ul>
+          <li>HTTPS encryption for all connections</li>
+          <li>Regular security updates and monitoring</li>
+          <li>Minimal data collection practices</li>
+        </ul>
+      </section>
+      
+      <section>
+        <h2>Changes to This Policy</h2>
+        <p>This Privacy Policy may be updated from time to time. Any changes will be posted on this page with an updated revision date. Continued use of the Website after changes constitutes acceptance of the updated policy.</p>
+      </section>
+      
+      <section>
+        <h2>Contact Information</h2>
+        <p>If you have any questions about this Privacy Policy or your data, please contact me through the contact form on the main website or via the social links provided in the footer.</p>
+      </section>
+    </main>
+    
+    <footer>
+      <nav class="footer-links">
+        <a href="/privacy">Privacy Policy</a>
+        <a href="/terms">Terms of Service</a>
+        <a href="/cookies">Cookie Policy</a>
+        <a href="/">Back to Portfolio</a>
+      </nav>
+      <p class="copyright">© 2026 <span class="name">Kevin Henderson</span>. All rights reserved.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/public/terms.html
+++ b/public/terms.html
@@ -1,0 +1,354 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms of Service - Kevin Henderson</title>
+  <meta name="description" content="Terms of Service for Kevin Henderson's portfolio website. Read the terms and conditions for using this website.">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+  
+  <!-- Font preconnect -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  
+  <!-- Theme -->
+  <meta name="theme-color" content="#0ea5e9">
+  <meta name="color-scheme" content="dark">
+  
+  <style>
+    *, *::before, *::after {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+    
+    html {
+      scroll-behavior: smooth;
+    }
+    
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: linear-gradient(to bottom right, #020617, #111827, #020617);
+      color: #d1d5db;
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+    
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+    
+    /* Header */
+    header {
+      padding: 2rem 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+      margin-bottom: 3rem;
+    }
+    
+    .back-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: #60a5fa;
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: color 0.2s ease;
+      margin-bottom: 1.5rem;
+    }
+    
+    .back-link:hover {
+      color: #93c5fd;
+    }
+    
+    .back-link svg {
+      width: 1rem;
+      height: 1rem;
+    }
+    
+    h1 {
+      font-size: clamp(2rem, 5vw, 2.5rem);
+      font-weight: 700;
+      color: white;
+      margin-bottom: 0.5rem;
+      background: linear-gradient(135deg, #7dd3fc, #10b981);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    
+    .last-updated {
+      font-size: 0.875rem;
+      color: #9ca3af;
+    }
+    
+    /* Main content */
+    main {
+      padding-bottom: 4rem;
+    }
+    
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: white;
+      margin-top: 2.5rem;
+      margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    }
+    
+    h3 {
+      font-size: 1.125rem;
+      font-weight: 600;
+      color: #e5e7eb;
+      margin-top: 1.5rem;
+      margin-bottom: 0.75rem;
+    }
+    
+    p {
+      margin-bottom: 1rem;
+    }
+    
+    ul {
+      margin-bottom: 1rem;
+      padding-left: 1.5rem;
+    }
+    
+    li {
+      margin-bottom: 0.5rem;
+    }
+    
+    a {
+      color: #60a5fa;
+      text-decoration: none;
+      transition: color 0.2s ease;
+    }
+    
+    a:hover {
+      color: #93c5fd;
+    }
+    
+    .highlight-box {
+      background: rgba(14, 165, 233, 0.1);
+      border: 1px solid rgba(14, 165, 233, 0.2);
+      border-radius: 0.5rem;
+      padding: 1rem 1.5rem;
+      margin: 1.5rem 0;
+    }
+    
+    .warning-box {
+      background: rgba(245, 158, 11, 0.1);
+      border: 1px solid rgba(245, 158, 11, 0.2);
+      border-radius: 0.5rem;
+      padding: 1rem 1.5rem;
+      margin: 1.5rem 0;
+    }
+    
+    /* Footer */
+    footer {
+      border-top: 1px solid rgba(255, 255, 255, 0.1);
+      padding: 2rem 0;
+      margin-top: 3rem;
+    }
+    
+    .footer-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    
+    .footer-links a {
+      font-size: 0.875rem;
+      color: #9ca3af;
+    }
+    
+    .footer-links a:hover {
+      color: white;
+    }
+    
+    .copyright {
+      font-size: 0.75rem;
+      color: #6b7280;
+    }
+    
+    .copyright .name {
+      font-weight: 600;
+      background: linear-gradient(135deg, #7dd3fc, #10b981);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    
+    /* Responsive */
+    @media (max-width: 640px) {
+      .container {
+        padding: 1.5rem 1rem;
+      }
+      
+      h1 {
+        font-size: 1.75rem;
+      }
+      
+      h2 {
+        font-size: 1.25rem;
+      }
+      
+      .footer-links {
+        flex-direction: column;
+        gap: 1rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <a href="/" class="back-link">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+        </svg>
+        Back to Portfolio
+      </a>
+      <h1>Terms of Service</h1>
+      <p class="last-updated">Last updated: January 25, 2026</p>
+    </header>
+    
+    <main>
+      <section>
+        <h2>Acceptance of Terms</h2>
+        <p>By accessing and using Kevin Henderson's portfolio website ("the Website"), you accept and agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use the Website.</p>
+        <p>These terms apply to all visitors, users, and others who access or use the Website.</p>
+      </section>
+      
+      <section>
+        <h2>Use of Website</h2>
+        
+        <h3>Permitted Uses</h3>
+        <p>You may use this Website for:</p>
+        <ul>
+          <li>Viewing portfolio content and projects</li>
+          <li>Learning about Kevin Henderson's work and experience</li>
+          <li>Contacting Kevin Henderson through provided channels</li>
+          <li>Sharing links to the Website</li>
+        </ul>
+        
+        <h3>Prohibited Activities</h3>
+        <p>You agree not to:</p>
+        <ul>
+          <li>Use the Website for any unlawful purpose or in violation of any applicable laws</li>
+          <li>Attempt to gain unauthorized access to any portion of the Website or its systems</li>
+          <li>Interfere with or disrupt the Website's operation or servers</li>
+          <li>Scrape, copy, or redistribute Website content without permission</li>
+          <li>Use automated systems (bots, scrapers) to access the Website in a manner that exceeds reasonable use</li>
+          <li>Impersonate Kevin Henderson or misrepresent affiliation with the Website</li>
+          <li>Use the Website to transmit malware, spam, or harmful content</li>
+        </ul>
+      </section>
+      
+      <section>
+        <h2>Intellectual Property</h2>
+        
+        <h3>Copyright Notice</h3>
+        <div class="highlight-box">
+          <p>All content on this Website, including but not limited to text, graphics, logos, images, code samples, and portfolio projects, is the property of Kevin Henderson and is protected by copyright and intellectual property laws.</p>
+        </div>
+        
+        <h3>Portfolio Content Ownership</h3>
+        <p>The projects, code, designs, and creative works displayed in the portfolio section are owned by Kevin Henderson unless otherwise noted. Some projects may be:</p>
+        <ul>
+          <li>Open source projects available under specific licenses (see individual project repositories)</li>
+          <li>Collaborations with other creators or organizations (credited appropriately)</li>
+          <li>Work created as part of employment or contract work (used with permission)</li>
+        </ul>
+        
+        <h3>Usage Restrictions</h3>
+        <p>You may not reproduce, distribute, modify, create derivative works from, publicly display, or commercially exploit any content from this Website without explicit written permission, except for:</p>
+        <ul>
+          <li>Personal, non-commercial reference</li>
+          <li>Open source projects used according to their respective licenses</li>
+          <li>Brief quotations for commentary or review purposes (with attribution)</li>
+        </ul>
+      </section>
+      
+      <section>
+        <h2>Third-Party Links</h2>
+        <p>The Website may contain links to third-party websites or services, including:</p>
+        <ul>
+          <li>GitHub repositories</li>
+          <li>Social media profiles</li>
+          <li>Music streaming platforms</li>
+          <li>External tools and resources</li>
+        </ul>
+        <p>These links are provided for convenience only. Kevin Henderson is not responsible for the content, privacy policies, or practices of any third-party websites. Visiting external links is at your own risk.</p>
+      </section>
+      
+      <section>
+        <h2>Disclaimer of Warranties</h2>
+        <div class="warning-box">
+          <p><strong>THE WEBSITE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED.</strong></p>
+        </div>
+        <p>Kevin Henderson does not warrant that:</p>
+        <ul>
+          <li>The Website will be uninterrupted, secure, or error-free</li>
+          <li>Any defects or errors will be corrected</li>
+          <li>The Website is free of viruses or harmful components</li>
+          <li>The information provided is accurate, complete, or current</li>
+        </ul>
+      </section>
+      
+      <section>
+        <h2>Limitation of Liability</h2>
+        <p>To the fullest extent permitted by applicable law, Kevin Henderson shall not be liable for any indirect, incidental, special, consequential, or punitive damages, including but not limited to:</p>
+        <ul>
+          <li>Loss of data or information</li>
+          <li>Loss of profits or revenue</li>
+          <li>Personal injury or property damage</li>
+          <li>Interruption of business</li>
+        </ul>
+        <p>This limitation applies regardless of whether the damages arise from use of the Website, inability to use the Website, or any content obtained from the Website.</p>
+      </section>
+      
+      <section>
+        <h2>Indemnification</h2>
+        <p>You agree to indemnify and hold harmless Kevin Henderson from any claims, damages, losses, liabilities, costs, or expenses (including reasonable attorneys' fees) arising from your use of the Website or violation of these Terms.</p>
+      </section>
+      
+      <section>
+        <h2>Governing Law</h2>
+        <p>These Terms of Service shall be governed by and construed in accordance with the laws of the State of Texas, United States, without regard to its conflict of law provisions.</p>
+        <p>Any disputes arising from these Terms or use of the Website shall be resolved in the state or federal courts located in Texas, and you consent to the personal jurisdiction of such courts.</p>
+      </section>
+      
+      <section>
+        <h2>Changes to Terms</h2>
+        <p>Kevin Henderson reserves the right to modify or replace these Terms at any time. Changes will be posted on this page with an updated revision date.</p>
+        <p>Your continued use of the Website after any changes constitutes acceptance of the new Terms. It is your responsibility to review these Terms periodically for changes.</p>
+      </section>
+      
+      <section>
+        <h2>Severability</h2>
+        <p>If any provision of these Terms is found to be unenforceable or invalid, that provision shall be limited or eliminated to the minimum extent necessary, and the remaining provisions shall remain in full force and effect.</p>
+      </section>
+      
+      <section>
+        <h2>Contact Information</h2>
+        <p>If you have any questions about these Terms of Service, please contact me through the contact form on the main website or via the social links provided in the footer.</p>
+      </section>
+    </main>
+    
+    <footer>
+      <nav class="footer-links">
+        <a href="/privacy">Privacy Policy</a>
+        <a href="/terms">Terms of Service</a>
+        <a href="/cookies">Cookie Policy</a>
+        <a href="/">Back to Portfolio</a>
+      </nav>
+      <p class="copyright">© 2026 <span class="name">Kevin Henderson</span>. All rights reserved.</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,7 +100,7 @@ function App() {
             <AboutSection />
           </section>
 
-          <section id="development" className="section-container relative min-h-[110vh] bg-gradient-to-br from-emerald-900 via-teal-900 to-cyan-900">
+          <section id="development" className="section-container relative min-h-[110vh] bg-slate-950">
             <DevelopmentSection />
           </section>
 
@@ -108,7 +108,7 @@ function App() {
             <MusicSection />
           </section>
 
-          <section id="contact" className="section-container relative min-h-[110vh] bg-gradient-to-br from-indigo-900 via-purple-900 to-pink-900">
+          <section id="contact" className="section-container relative  bg-gradient-to-b from-stone-950 via-neutral-950 to-zinc-950">
             <ContactSection />
           </section>
           </Suspense>

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -1,97 +1,132 @@
-
 import { useRef, useEffect } from 'react';
 import {
   LuMapPin,
-  LuPhone,
   LuMail,
   LuLinkedin,
   LuGithub,
-
   LuCalendar,
-  LuSend,
-  LuCheck,
-  LuX,
-  LuMessageCircle
+  LuMusic,
+  LuDisc,
+  LuPlay,
+  LuPause,
 } from 'react-icons/lu';
 import { animations, killScrollTriggersFor, killTweensFor } from '../utils/animations';
 
 // Icon mapping for consistent styling and semantic meaning
 const ContactIcons = {
   location: LuMapPin,
-  phone: LuPhone,
   email: LuMail,
   linkedin: LuLinkedin,
   github: LuGithub,
-
   calendar: LuCalendar,
-  send: LuSend,
-  success: LuCheck,
-  error: LuX,
 } as const;
+
+// Cassette tape screw component
+const CassetteScrew = ({ className = '' }: { className?: string }) => (
+  <div
+    className={`w-4 h-4 rounded-full bg-gradient-to-br from-zinc-400 to-zinc-600 shadow-inner flex items-center justify-center ${className}`}
+    aria-hidden="true"
+  >
+    <div className="w-2 h-0.5 bg-zinc-700 rounded-full" />
+  </div>
+);
+
+// Tape reel component with spinning animation
+const TapeReel = ({
+  size = 'lg',
+  spinning = false,
+}: {
+  size?: 'sm' | 'lg';
+  spinning?: boolean;
+}) => {
+  const sizeClasses = size === 'lg' ? 'w-24 h-24 md:w-32 md:h-32' : 'w-16 h-16 md:w-20 md:h-20';
+
+  return (
+    <div
+      className={`${sizeClasses} rounded-full bg-gradient-to-br from-zinc-900 via-zinc-800 to-zinc-900 shadow-lg flex items-center justify-center ${
+        spinning ? 'animate-spin' : ''
+      }`}
+      style={{ animationDuration: '3s' }}
+      aria-hidden="true"
+    >
+      {/* Outer ring */}
+      <div className="absolute inset-2 rounded-full border-2 border-zinc-700" />
+      {/* Spokes */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        {[0, 60, 120, 180, 240, 300].map((rotation) => (
+          <div
+            key={rotation}
+            className="absolute w-full h-0.5 bg-zinc-700"
+            style={{ transform: `rotate(${rotation}deg)` }}
+          />
+        ))}
+      </div>
+      {/* Center hub */}
+      <div className="w-6 h-6 md:w-8 md:h-8 rounded-full bg-gradient-to-br from-zinc-600 to-zinc-800 border-2 border-zinc-500 z-10 flex items-center justify-center">
+        <div className="w-2 h-2 md:w-3 md:h-3 rounded-full bg-zinc-400" />
+      </div>
+    </div>
+  );
+};
 
 function ContactSection() {
   // Animation refs
   const sectionRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
-  const contactCardRef = useRef<HTMLDivElement>(null);
-  const linksRef = useRef<HTMLDivElement>(null);
+  const cassetteRef = useRef<HTMLDivElement>(null);
+  const vinylRef = useRef<HTMLDivElement>(null);
 
   const contactInfo = {
-    email: "primary-email@kevinhenderson.dev",
-    phone: "+1 (555) 123-4567",
-    location: "San Antonio, TX",
-    availability: "Available for full-time opportunities"
+    email: 'primary-email@kevinhenderson.dev',
+    location: 'San Antonio, TX',
+    availability: 'Available for full-time opportunities',
   };
 
   const professionalLinks = [
     {
-      href: "mailto:primary-email@kevinhenderson.dev",
-      icon: "email",
-      label: "Email",
-      description: "Send me a message",
-      primary: true
+      href: 'mailto:primary-email@kevinhenderson.dev',
+      icon: 'email',
+      label: 'Email',
+      description: 'Drop a line',
+      color: 'from-amber-500 to-orange-600',
     },
     {
-      href: "https://www.linkedin.com/in/kevin-h-cs/",
-      icon: "linkedin",
-      label: "LinkedIn",
-      description: "Professional network",
-      primary: true
+      href: 'https://www.linkedin.com/in/kevin-h-cs/',
+      icon: 'linkedin',
+      label: 'LinkedIn',
+      description: 'Connect',
+      color: 'from-blue-500 to-blue-700',
     },
     {
-      href: "https://github.com/khenderson20",
-      icon: "github",
-      label: "GitHub",
-      description: "View my code",
-      primary: true
+      href: 'https://github.com/khenderson20',
+      icon: 'github',
+      label: 'GitHub',
+      description: 'View code',
+      color: 'from-zinc-600 to-zinc-800',
     },
     {
-      href: "https://calendly.com/primary-email-kevinhenderson/one-on-one",
-      icon: "calendar",
-      label: "Schedule a Meeting",
-      description: "Book a meeting",
-      primary: false
-    }
+      href: 'https://calendly.com/primary-email-kevinhenderson/one-on-one',
+      icon: 'calendar',
+      label: 'Book a Call',
+      description: 'Schedule',
+      color: 'from-emerald-500 to-teal-600',
+    },
   ] as const;
 
   // Animation setup
   useEffect(() => {
-    // Capture ref values for cleanup to avoid stale `.current` warnings
     const sectionEl = sectionRef.current;
     const headerEl = headerRef.current;
-    const contactCardEl = contactCardRef.current;
-    const linkEls = linksRef.current?.children ? Array.from(linksRef.current.children) : [];
+    const cassetteEl = cassetteRef.current;
+    const vinylEl = vinylRef.current;
 
-    // Optimized delay to ensure DOM elements are fully rendered after lazy loading
     const timer = setTimeout(() => {
-      // Section entrance animation - using ScrollTrigger for smooth entrance
       animations.fadeIn(sectionRef.current, {
         duration: 1.2,
-        y: 20, // Reduced from 40 to prevent overflow
+        y: 20,
         scrollTrigger: true,
       });
 
-      // Header animation - with scroll trigger for better visual impact
       animations.fadeIn(headerRef.current, {
         duration: 1,
         delay: 0.2,
@@ -99,41 +134,25 @@ function ContactSection() {
         scrollTrigger: true,
       });
 
-      // Contact card animation - with scroll trigger for better UX
-      animations.scaleIn(contactCardRef.current, {
+      animations.scaleIn(cassetteRef.current, {
         duration: 0.8,
         delay: 0.3,
         scale: 0.9,
         scrollTrigger: true,
       });
 
-      // Staggered links animation - with scroll trigger for better UX
-      if (linksRef.current?.children) {
-        animations.staggerFadeIn(linksRef.current.children, {
-          duration: 0.6,
-          stagger: 0.1,
-          delay: 0.4,
-          y: 20,
-          scrollTrigger: true,
-        });
-      }
-    }, 150); // Optimized delay for DOM readiness
+      animations.scaleIn(vinylRef.current, {
+        duration: 0.8,
+        delay: 0.4,
+        scale: 0.9,
+        scrollTrigger: true,
+      });
+    }, 150);
 
     return () => {
       clearTimeout(timer);
-      // Targeted cleanup for this section only
-      killScrollTriggersFor([
-        sectionEl,
-        headerEl,
-        contactCardEl,
-        linkEls,
-      ]);
-      killTweensFor([
-        sectionEl,
-        headerEl,
-        contactCardEl,
-        linkEls,
-      ]);
+      killScrollTriggersFor([sectionEl, headerEl, cassetteEl, vinylEl]);
+      killTweensFor([sectionEl, headerEl, cassetteEl, vinylEl]);
     };
   }, []);
 
@@ -143,116 +162,279 @@ function ContactSection() {
       className="relative min-h-screen py-6 px-8"
       aria-labelledby="contact-heading"
     >
-      {/* Background Elements */}
-      <div className="pointer-events-none absolute -inset-x-16 -top-16 -bottom-0 md:-inset-x-24 md:-top-24 md:-bottom-0">
-        <div className="absolute inset-0 opacity-30">
-          <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-indigo-500 rounded-full mix-blend-overlay filter blur-xl opacity-20 animate-pulse"></div>
-          <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-purple-500 rounded-full mix-blend-overlay filter blur-xl opacity-20 animate-pulse animation-delay-2000"></div>
-          <div className="absolute top-3/4 right-1/3 w-96 h-96 bg-pink-500 rounded-full mix-blend-overlay filter blur-xl opacity-20 animate-pulse animation-delay-4000"></div>
+      {/* Cassette Tape Background Pattern */}
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        {/* Dark warm gradient overlay - nostalgic cassette tape feel */}
+        <div className="absolute inset-0 bg-gradient-to-b from-stone-900/40 via-neutral-950/60 to-stone-900/40" />
+        {/* Subtle amber accent glow at edges */}
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-amber-900/15 via-transparent to-transparent" />
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom,_var(--tw-gradient-stops))] from-stone-800/20 via-transparent to-transparent" />
+        {/* Film grain / tape texture overlay */}
+        <div
+          className="absolute inset-0 opacity-20"
+          style={{
+            backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='5' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E")`,
+          }}
+        />
+        {/* Vintage scan lines - like old CRT/analog displays */}
+        <div className="absolute inset-0 opacity-[0.03]">
+          {Array.from({ length: 60 }).map((_, i) => (
+            <div
+              key={i}
+              className="absolute w-full h-px bg-amber-100"
+              style={{ top: `${i * 1.67}%` }}
+            />
+          ))}
         </div>
+        {/* Corner vignette for that worn tape look */}
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,_transparent_30%,_rgba(0,0,0,0.4)_100%)]" />
       </div>
 
       <div className="container-responsive relative z-10 section-content-container mb-0">
         <header ref={headerRef} className="text-center mb-16">
-          <div className="inline-flex items-center gap-3 mb-6 px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full border border-white/20">
-            <LuMessageCircle className="w-5 h-5 text-indigo-300" />
-            <span className="text-indigo-200 font-medium">Contact</span>
+          <div className="inline-flex items-center gap-3 mb-6 px-6 py-3 bg-gradient-to-r from-amber-800/40 to-orange-800/40 backdrop-blur-sm rounded-full border border-amber-500/30">
+            <LuMusic className="w-5 h-5 text-amber-300" />
+            <span className="text-amber-200 font-medium tracking-wider uppercase text-sm">
+              Now Playing
+            </span>
           </div>
 
-          <h2 id="contact-heading" className="text-4xl md:text-6xl lg:text-7xl font-bold mb-6 text-white">
-            <span className="gradient-text">Let's Connect</span>
+          <h2
+            id="contact-heading"
+            className="text-4xl md:text-6xl lg:text-7xl font-bold mb-6"
+          >
+            <span
+              className="bg-gradient-to-r from-amber-200 via-orange-300 to-amber-200 bg-clip-text text-transparent"
+              style={{
+                fontFamily: "'Courier New', monospace",
+                textShadow: '0 0 40px rgba(251, 191, 36, 0.3)',
+              }}
+            >
+              Let's Connect
+            </span>
           </h2>
 
-          <p className="text-xl md:text-2xl text-gray-300 mb-12 max-w-3xl mx-auto leading-relaxed">
-            Ready to discuss opportunities and collaborate on exciting projects
+          <p
+            className="text-xl md:text-2xl text-amber-100/70 mb-12 max-w-3xl mx-auto leading-relaxed"
+            style={{ fontFamily: "'Georgia', serif" }}
+          >
+            Ready to spin up something amazing together
           </p>
         </header>
 
-        <div className="grid lg:grid-cols-2 gap-12 max-w-6xl mx-auto">
-          {/* Contact Information Card */}
+        <div className="grid lg:grid-cols-2 gap-8 max-w-6xl mx-auto">
+          {/* Cassette Tape Card */}
           <div
-            ref={contactCardRef}
-            className="glass-effect rounded-2xl p-8 md:p-12"
+            ref={cassetteRef}
+            className="relative rounded-2xl overflow-hidden"
             role="region"
             aria-labelledby="contact-info-heading"
           >
-            <header className="mb-8">
-              <h3 id="contact-info-heading" className="text-2xl md:text-3xl font-bold text-white mb-4">
-                Get In Touch
-              </h3>
-              <p className="text-lg text-indigo-200 font-medium" role="status" aria-live="polite">
-                {contactInfo.availability}
-              </p>
-            </header>
-
-            <div className="space-y-6 mb-8">
-              <div className="flex items-center gap-4">
-                <div className="w-12 h-12 bg-indigo-600 rounded-lg flex items-center justify-center">
-                  <ContactIcons.location className="w-6 h-6 text-white" aria-hidden="true" />
+            {/* Cassette Body */}
+            <div className="relative bg-gradient-to-br from-amber-100 via-amber-50 to-stone-100 p-1 rounded-2xl shadow-2xl">
+              {/* Inner cassette frame */}
+              <div className="bg-gradient-to-br from-stone-800 via-stone-900 to-zinc-900 rounded-xl p-6 md:p-8">
+                {/* Top screws */}
+                <div className="flex justify-between items-center mb-4">
+                  <CassetteScrew />
+                  <div className="px-4 py-1.5 bg-amber-100 rounded text-xs font-bold text-stone-700 tracking-widest uppercase shadow-sm">
+                    Contact Mix Vol. 1
+                  </div>
+                  <CassetteScrew />
                 </div>
-                <div>
-                  <span className="block text-sm text-gray-400 uppercase tracking-wide">Location</span>
-                  <span className="text-lg text-white font-medium">{contactInfo.location}</span>
-                </div>
-              </div>
-            </div>
 
-            {/* Professional Links */}
-            <div>
-              <h4 className="text-xl font-bold text-white mb-6">Connect With Me</h4>
-              <div ref={linksRef} className="grid grid-cols-2 gap-4">
-                {professionalLinks.map((link, index) => {
-                  const IconComponent = ContactIcons[link.icon as keyof typeof ContactIcons];
-                  return (
-                    <a
-                      key={index}
-                      href={link.href}
-                      className={`group flex items-center gap-3 p-4 rounded-xl transition-all duration-300 transform hover:scale-105 ${
-                        link.primary
-                          ? 'bg-indigo-600 hover:bg-indigo-700 text-white shadow-lg hover:shadow-indigo-500/25'
-                          : 'bg-white/10 hover:bg-white/20 text-gray-300 hover:text-white'
-                      }`}
-                      target={link.href.startsWith('http') ? '_blank' : '_self'}
-                      rel={link.href.startsWith('http') ? 'noopener noreferrer' : ''}
-                      aria-label={`${link.label} - ${link.description}${link.href.startsWith('http') ? ' (opens in new tab)' : ''}`}
+                {/* Tape Window */}
+                <div className="relative bg-gradient-to-b from-stone-950 to-stone-900 rounded-lg p-4 mb-6 border-2 border-stone-700">
+                  {/* Tape reels container */}
+                  <div className="flex justify-between items-center">
+                    <TapeReel size="lg" spinning />
+                    <div className="flex-1 mx-4">
+                      {/* Tape path */}
+                      <div className="h-1 bg-gradient-to-r from-amber-800 via-amber-600 to-amber-800 rounded-full mb-2" />
+                      <div className="h-1 bg-gradient-to-r from-amber-800 via-amber-600 to-amber-800 rounded-full" />
+                    </div>
+                    <TapeReel size="lg" />
+                  </div>
+
+                  {/* Tape counter display */}
+                  <div className="absolute top-2 right-2 bg-zinc-900/95 px-2 py-1 rounded text-xs font-mono text-emerald-400 border border-zinc-700 z-10">
+                    00:42
+                  </div>
+                </div>
+
+                {/* Label Area - Clear separation from tape window */}
+                <div className="relative bg-gradient-to-br from-amber-100 to-orange-100 rounded-lg p-5 mb-4 shadow-inner z-10">
+                  <div className="text-center mb-3">
+                    <h3
+                      id="contact-info-heading"
+                      className="text-xl md:text-2xl font-bold text-stone-800 mb-2"
+                      style={{ fontFamily: "'Georgia', serif" }}
                     >
-                      <IconComponent className="w-5 h-5 flex-shrink-0" aria-hidden="true" />
-                      <div className="flex-1 min-w-0">
-                        <div className="font-semibold truncate">{link.label}</div>
-                        <div className="text-sm opacity-75 truncate">{link.description}</div>
-                      </div>
-                    </a>
-                  );
-                })}
+                      Get In Touch
+                    </h3>
+                    <p className="text-sm text-stone-600 font-medium">{contactInfo.availability}</p>
+                  </div>
+
+                  <div className="flex items-center justify-center gap-2 text-sm text-stone-700 font-medium">
+                    <ContactIcons.location className="w-4 h-4 text-amber-700" />
+                    <span>{contactInfo.location}</span>
+                  </div>
+                </div>
+
+                {/* Control buttons / Links */}
+                <div className="grid grid-cols-2 gap-3">
+                  {professionalLinks.map((link, index) => {
+                    const IconComponent =
+                      ContactIcons[link.icon as keyof typeof ContactIcons];
+                    return (
+                      <a
+                        key={index}
+                        href={link.href}
+                        className={`group relative flex items-center gap-3 p-3 rounded-lg bg-gradient-to-br ${link.color} text-white transition-all duration-300 hover:scale-105 hover:shadow-lg hover:shadow-amber-500/20`}
+                        target={link.href.startsWith('http') ? '_blank' : '_self'}
+                        rel={link.href.startsWith('http') ? 'noopener noreferrer' : ''}
+                        aria-label={`${link.label} - ${link.description}${link.href.startsWith('http') ? ' (opens in new tab)' : ''}`}
+                      >
+                        <div className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center">
+                          <IconComponent className="w-4 h-4" aria-hidden="true" />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <div className="font-semibold text-sm truncate">
+                            {link.label}
+                          </div>
+                          <div className="text-xs opacity-80 truncate">
+                            {link.description}
+                          </div>
+                        </div>
+                      </a>
+                    );
+                  })}
+                </div>
+
+                {/* Bottom screws */}
+                <div className="flex justify-between mt-4">
+                  <CassetteScrew />
+                  <CassetteScrew />
+                </div>
               </div>
             </div>
           </div>
 
-          {/* Additional Contact Methods */}
-          <div className="glass-effect rounded-2xl p-8 md:p-12">
-            <h3 className="text-2xl md:text-3xl font-bold text-white mb-8">
-              Other Ways to Connect
-            </h3>
+          {/* Vinyl Record Card */}
+          <div ref={vinylRef} className="relative">
+            <div className="relative bg-gradient-to-br from-stone-900 via-zinc-900 to-stone-950 rounded-2xl p-6 md:p-8 shadow-2xl border border-stone-700/50 overflow-hidden">
+              {/* Album sleeve texture - reduced opacity to not interfere with content */}
+              <div className="absolute inset-0 opacity-5 pointer-events-none">
+                <div
+                  className="w-full h-full"
+                  style={{
+                    backgroundImage:
+                      'repeating-linear-gradient(90deg, transparent, transparent 2px, rgba(255,255,255,0.03) 2px, rgba(255,255,255,0.03) 4px)',
+                  }}
+                />
+              </div>
 
-            <div className="space-y-6">
-              <div className="flex items-center gap-4">
-                <div className="w-12 h-12 bg-purple-600 rounded-lg flex items-center justify-center">
-                  <ContactIcons.email className="w-6 h-6 text-white" />
-                </div>
-                <div>
-                  <span className="block text-sm text-gray-400 uppercase tracking-wide">Email</span>
-                  <a href={`mailto:${contactInfo.email}`} className="text-lg text-white font-medium hover:text-purple-300 transition-colors">
-                    {contactInfo.email}
-                  </a>
+              {/* Vinyl Record */}
+              <div className="relative flex justify-center mb-8 z-10">
+                <div
+                  className="relative w-48 h-48 md:w-64 md:h-64 rounded-full bg-gradient-to-br from-zinc-900 via-zinc-800 to-black shadow-2xl group hover:animate-spin"
+                  style={{ animationDuration: '4s' }}
+                  aria-hidden="true"
+                >
+                  {/* Grooves */}
+                  {[...Array(12)].map((_, i) => (
+                    <div
+                      key={i}
+                      className="absolute rounded-full border border-zinc-700/30"
+                      style={{
+                        inset: `${8 + i * 6}%`,
+                      }}
+                    />
+                  ))}
+
+                  {/* Center label */}
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <div className="w-20 h-20 md:w-28 md:h-28 rounded-full bg-gradient-to-br from-amber-400 via-orange-500 to-red-600 flex items-center justify-center shadow-lg">
+                      <div className="text-center">
+                        <LuDisc className="w-6 h-6 md:w-8 md:h-8 mx-auto text-white mb-1" />
+                        <div
+                          className="text-xs md:text-sm font-bold text-white tracking-wider drop-shadow-sm"
+                          style={{ fontFamily: "'Courier New', monospace" }}
+                        >
+                          KEVIN
+                        </div>
+                        <div className="text-[8px] md:text-[10px] text-white/90 font-medium">
+                          HENDERSON
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Light reflection */}
+                  <div className="absolute inset-0 rounded-full bg-gradient-to-tr from-transparent via-white/5 to-transparent pointer-events-none" />
                 </div>
               </div>
 
+              {/* Album info - elevated z-index for clear visibility */}
+              <div className="relative text-center space-y-4 z-10">
+                <h3
+                  className="text-2xl md:text-3xl font-bold text-amber-100 drop-shadow-sm"
+                  style={{ fontFamily: "'Georgia', serif" }}
+                >
+                  Other Ways to Connect
+                </h3>
 
-              <div className="mt-8 p-6 bg-white/5 rounded-xl border border-white/10">
-                <p className="text-gray-300 leading-relaxed">
-                  I'm always excited to discuss new opportunities, collaborate on interesting projects,
-                  or simply connect with fellow developers and creators. Feel free to reach out!
-                </p>
+                <div className="inline-flex items-center gap-4 px-4 py-2 bg-stone-800/80 backdrop-blur-sm rounded-full border border-stone-700">
+                  <button
+                    className="w-8 h-8 rounded-full bg-amber-500 hover:bg-amber-400 flex items-center justify-center transition-colors"
+                    aria-label="Play"
+                  >
+                    <LuPlay className="w-4 h-4 text-stone-900 ml-0.5" />
+                  </button>
+                  <button
+                    className="w-8 h-8 rounded-full bg-stone-700 hover:bg-stone-600 flex items-center justify-center transition-colors"
+                    aria-label="Pause"
+                  >
+                    <LuPause className="w-4 h-4 text-amber-100" />
+                  </button>
+                  <div className="h-6 w-px bg-stone-600" />
+                  <span className="text-sm text-amber-200 font-mono font-medium">Track 02</span>
+                </div>
+
+                <div className="flex items-center justify-center gap-4 pt-4">
+                  <div className="w-12 h-12 bg-gradient-to-br from-amber-600 to-orange-700 rounded-lg flex items-center justify-center shadow-lg flex-shrink-0">
+                    <ContactIcons.email className="w-6 h-6 text-white" />
+                  </div>
+                  <div className="text-left">
+                    <span className="block text-xs text-amber-300 uppercase tracking-wider font-semibold">
+                      Email
+                    </span>
+                    <a
+                      href={`mailto:${contactInfo.email}`}
+                      className="text-amber-100 hover:text-amber-200 transition-colors font-medium"
+                    >
+                      {contactInfo.email}
+                    </a>
+                  </div>
+                </div>
+
+                <div className="mt-6 p-4 bg-gradient-to-r from-amber-900/30 via-orange-900/30 to-amber-900/30 rounded-xl border border-amber-700/30 backdrop-blur-sm">
+                  <p
+                    className="text-amber-100/90 leading-relaxed text-sm md:text-base"
+                    style={{ fontFamily: "'Georgia', serif" }}
+                  >
+                    "I'm always excited to discuss new opportunities, collaborate on interesting
+                    projects, or simply connect with fellow developers and creators. Feel free
+                    to reach out!"
+                  </p>
+                </div>
+
+                {/* Vintage rating sticker */}
+                <div className="inline-flex items-center gap-2 px-4 py-1.5 bg-red-600 rounded-sm rotate-[-2deg] shadow-md">
+                  <span className="text-xs font-bold text-white tracking-wider uppercase drop-shadow-sm">
+                    ★ Highly Recommended ★
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -263,4 +445,3 @@ function ContactSection() {
 }
 
 export default ContactSection;
-

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -61,13 +61,13 @@ function Footer() {
               <ul className="space-y-3">
                 <li className="flex items-center gap-2">
                   <SiGithub className="w-4 h-4 text-gray-400" />
-                  <a href="https://github.com/kevinhenderson" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-300 hover:text-white transition-colors duration-200">
+                  <a href="https://github.com/khenderson20" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-300 hover:text-white transition-colors duration-200">
                     GitHub
                   </a>
                 </li>
                 <li className="flex items-center gap-2">
                   <SiLinkedin className="w-4 h-4 text-gray-400" />
-                  <a href="https://linkedin.com/in/kevinhenderson" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-300 hover:text-white transition-colors duration-200">
+                  <a href="https://www.linkedin.com/in/kevin-h-cs/" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-300 hover:text-white transition-colors duration-200">
                     LinkedIn
                   </a>
                 </li>

--- a/src/components/LanguageDistribution.tsx
+++ b/src/components/LanguageDistribution.tsx
@@ -1,0 +1,262 @@
+import { useMemo } from 'react';
+import { FaTerminal, FaJava } from 'react-icons/fa';
+import {
+  SiTypescript, SiJavascript, SiPython, SiVuedotjs, SiHtml5, SiCss3, SiNodedotjs,
+  SiC, SiCplusplus, SiMarkdown, SiPowers,
+  SiVim, SiGnu, SiGo, SiRust, SiDart,
+  SiKotlin, SiSwift, SiZig, SiJulia,
+  SiRuby, SiPhp, SiScala, SiElixir,
+  SiHaskell, SiSolidity, SiSvelte,
+  SiAstro, SiNextdotjs, SiRemix,
+  SiFlutter, SiReact, SiAngular,
+  SiDocker, SiTerraform, SiGraphql,
+  SiMysql, SiPostgresql, SiMongodb, SiRedis,
+  SiFirebase, SiAmazonwebservices,
+} from 'react-icons/si';
+import type { IconType } from 'react-icons';
+
+// Language color palette (GitHub-inspired colors)
+const LANGUAGE_COLORS: Record<string, string> = {
+  typescript: '#3178c6',
+  javascript: '#f7df1e',
+  python: '#3572A5',
+  vue: '#41b883',
+  html: '#e34c26',
+  css: '#563d7c',
+  node: '#339933',
+  shell: '#89e051',
+  bash: '#89e051',
+  c: '#555555',
+  cpp: '#f34b7d',
+  'c++': '#f34b7d',
+  java: '#b07219',
+  go: '#00ADD8',
+  rust: '#dea584',
+  dart: '#00B4AB',
+  kotlin: '#A97BFF',
+  swift: '#F05138',
+  ruby: '#701516',
+  php: '#4F5D95',
+  scala: '#c22d40',
+  elixir: '#6e4a7e',
+  haskell: '#5e5086',
+  vim: '#199f4b',
+  vimscript: '#199f4b',
+  makefile: '#427819',
+  cmake: '#DA3434',
+  make: '#427819',
+  markdown: '#083fa1',
+  react: '#61dafb',
+  angular: '#dd0031',
+  svelte: '#ff3e00',
+  docker: '#2496ED',
+  graphql: '#e10098',
+  sql: '#e38c00',
+  mysql: '#4479A1',
+  postgresql: '#336791',
+  mongodb: '#47A248',
+  redis: '#DC382D',
+  firebase: '#FFCA28',
+  aws: '#FF9900',
+};
+
+const TECH_ICON_MAP: Array<{
+  match: (t: string) => boolean;
+  icon: IconType;
+}> = [
+  { match: (t: string) => t === 'go' || t === 'golang', icon: SiGo },
+  { match: (t: string) => t === 'rust', icon: SiRust },
+  { match: (t: string) => t === 'dart', icon: SiDart },
+  { match: (t: string) => t === 'kotlin', icon: SiKotlin },
+  { match: (t: string) => t === 'swift', icon: SiSwift },
+  { match: (t: string) => t === 'zig', icon: SiZig },
+  { match: (t: string) => t === 'julia', icon: SiJulia },
+  { match: (t: string) => t === 'ruby', icon: SiRuby },
+  { match: (t: string) => t === 'php', icon: SiPhp },
+  { match: (t: string) => t === 'scala', icon: SiScala },
+  { match: (t: string) => t === 'elixir', icon: SiElixir },
+  { match: (t: string) => t === 'haskell', icon: SiHaskell },
+  { match: (t: string) => t === 'solidity', icon: SiSolidity },
+  { match: (t: string) => t === 'svelte', icon: SiSvelte },
+  { match: (t: string) => t === 'astro', icon: SiAstro },
+  { match: (t: string) => t === 'nextjs' || t === 'next', icon: SiNextdotjs },
+  { match: (t: string) => t === 'remix', icon: SiRemix },
+  { match: (t: string) => t === 'flutter', icon: SiFlutter },
+  { match: (t: string) => t === 'react', icon: SiReact },
+  { match: (t: string) => t === 'angular', icon: SiAngular },
+  { match: (t: string) => t === 'docker', icon: SiDocker },
+  { match: (t: string) => t === 'terraform', icon: SiTerraform },
+  { match: (t: string) => t === 'graphql', icon: SiGraphql },
+  { match: (t: string) => t === 'mysql', icon: SiMysql },
+  { match: (t: string) => t === 'postgresql' || t === 'postgres', icon: SiPostgresql },
+  { match: (t: string) => t === 'mongodb', icon: SiMongodb },
+  { match: (t: string) => t === 'redis', icon: SiRedis },
+  { match: (t: string) => t === 'firebase', icon: SiFirebase },
+  { match: (t: string) => t === 'aws' || t === 'amazonwebservices', icon: SiAmazonwebservices },
+  { match: (t: string) => t.includes('typescript'), icon: SiTypescript },
+  { match: (t: string) => t.includes('javascript'), icon: SiJavascript },
+  { match: (t: string) => t.includes('python'), icon: SiPython },
+  { match: (t: string) => t.includes('vue'), icon: SiVuedotjs },
+  { match: (t: string) => t.includes('html'), icon: SiHtml5 },
+  { match: (t: string) => t.includes('css'), icon: SiCss3 },
+  { match: (t: string) => t.includes('node'), icon: SiNodedotjs },
+  { match: (t: string) => ['bash', 'shell', 'sh'].includes(t), icon: FaTerminal },
+  { match: (t: string) => t === 'powershell', icon: SiPowers },
+  { match: (t: string) => t === 'c', icon: SiC },
+  { match: (t: string) => t === 'cpp' || t === 'c++', icon: SiCplusplus },
+  { match: (t: string) => t === 'java', icon: FaJava },
+  { match: (t: string) => t === 'md' || t === 'markdown', icon: SiMarkdown },
+  { match: (t: string) => t === 'vim' || t === 'vimscript', icon: SiVim },
+  { match: (t: string) => t === 'makefile' || t === 'make' || t === 'cmake', icon: SiGnu },
+];
+
+const normalize = (t?: string) => (t || '').toLowerCase().replace(/[^a-z0-9+]/g, '');
+
+function getIcon(techRaw: string): IconType {
+  const tech = normalize(techRaw);
+  for (const entry of TECH_ICON_MAP) {
+    if (entry.match(tech)) return entry.icon;
+  }
+  return FaTerminal;
+}
+
+function getColor(techRaw: string): string {
+  const tech = normalize(techRaw);
+  return LANGUAGE_COLORS[tech] || '#6b7280';
+}
+
+function getLabel(techRaw: string): string {
+  const labelMap: Record<string, string> = {
+    typescript: 'TypeScript',
+    javascript: 'JavaScript',
+    python: 'Python',
+    vue: 'Vue',
+    html: 'HTML',
+    css: 'CSS',
+    node: 'Node.js',
+    shell: 'Shell',
+    bash: 'Bash',
+    c: 'C',
+    cpp: 'C++',
+    'c++': 'C++',
+    java: 'Java',
+    go: 'Go',
+    rust: 'Rust',
+    dart: 'Dart',
+    kotlin: 'Kotlin',
+    swift: 'Swift',
+    ruby: 'Ruby',
+    php: 'PHP',
+    vim: 'Vim Script',
+    vimscript: 'Vim Script',
+    makefile: 'Make',
+    cmake: 'CMake',
+    markdown: 'Markdown',
+  };
+  const tech = normalize(techRaw);
+  return labelMap[tech] || techRaw;
+}
+
+interface LanguageDistributionProps {
+  techCounts: Record<string, number>;
+  onSelectTech?: (tech: string | null) => void;
+  selectedTech?: string | null;
+}
+
+export default function LanguageDistribution({
+  techCounts,
+  onSelectTech,
+  selectedTech
+}: LanguageDistributionProps) {
+  // Calculate distribution
+  const distribution = useMemo(() => {
+    const total = Object.values(techCounts).reduce((sum, count) => sum + count, 0);
+    if (total === 0) return [];
+
+    return Object.entries(techCounts)
+      .map(([tech, count]) => ({
+        tech,
+        normalized: normalize(tech),
+        count,
+        percentage: (count / total) * 100,
+        color: getColor(tech),
+        icon: getIcon(tech),
+        label: getLabel(tech),
+      }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 8); // Top 8 languages
+  }, [techCounts]);
+
+  if (distribution.length === 0) return null;
+
+  const total = Object.values(techCounts).reduce((sum, count) => sum + count, 0);
+
+  return (
+    <div className="glass-effect rounded-2xl border border-white/20 p-6 mb-8">
+      <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+        <span className="w-2 h-2 rounded-full bg-emerald-400"></span>
+        Language Distribution
+      </h3>
+
+      {/* Horizontal bar visualization */}
+      <div className="mb-6">
+        <div className="h-4 rounded-full overflow-hidden flex bg-white/5" role="img" aria-label="Language distribution bar">
+          {distribution.map(({ normalized, percentage, color }, idx) => (
+            <div
+              key={normalized}
+              className={`h-full transition-all duration-300 cursor-pointer hover:brightness-125 ${
+                selectedTech && selectedTech !== normalized ? 'opacity-40' : ''
+              }`}
+              style={{
+                width: `${percentage}%`,
+                backgroundColor: color,
+                marginLeft: idx > 0 ? '2px' : 0,
+              }}
+              onClick={() => onSelectTech?.(selectedTech === normalized ? null : normalized)}
+              title={`${getLabel(normalized)}: ${percentage.toFixed(1)}%`}
+              role="button"
+              aria-label={`${getLabel(normalized)}: ${percentage.toFixed(1)}%`}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Legend with details */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {distribution.map(({ normalized, count, percentage, color, icon: Icon, label }) => (
+          <button
+            key={normalized}
+            onClick={() => onSelectTech?.(selectedTech === normalized ? null : normalized)}
+            className={`
+              flex items-center gap-2 p-2 rounded-lg transition-all duration-200 text-left
+              ${selectedTech === normalized
+                ? 'bg-white/15 ring-2 ring-white/30'
+                : selectedTech
+                  ? 'opacity-50 hover:opacity-80'
+                  : 'hover:bg-white/10'
+              }
+            `}
+          >
+            <div
+              className="w-3 h-3 rounded-sm shrink-0"
+              style={{ backgroundColor: color }}
+            />
+            <Icon className="w-4 h-4 shrink-0" style={{ color }} />
+            <div className="min-w-0 flex-1">
+              <div className="text-sm font-medium text-white truncate">{label}</div>
+              <div className="text-xs text-gray-400">
+                {count} project{count !== 1 ? 's' : ''} · {percentage.toFixed(0)}%
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {/* Total projects indicator */}
+      <div className="mt-4 pt-4 border-t border-white/10 flex items-center justify-between text-sm">
+        <span className="text-gray-400">Total unique technologies across projects</span>
+        <span className="text-emerald-400 font-semibold">{total}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MusicSection.tsx
+++ b/src/components/MusicSection.tsx
@@ -1,11 +1,9 @@
 import TrackCard from './TrackCard';
 import InteractiveCard from './InteractiveCard';
 import MusicStatCard from './MusicStatCard';
-import { FaSpotify, FaSoundcloud, FaUsers, FaMusic, FaCompactDisc } from 'react-icons/fa';
+import { FaSpotify, FaSoundcloud, FaUsers, FaMusic, FaCompactDisc, FaHeadphones } from 'react-icons/fa';
 import { useEffect, useRef } from 'react';
 import { animations, killScrollTriggersFor, killTweensFor } from '../utils/animations';
-import { Typography } from '@material-tailwind/react';
-
 
 interface Track {
   title: string;
@@ -41,41 +39,38 @@ function MusicSection() {
   ];
 
   const audioStats = [
-    { label: "Monthly Listeners", value: 4, suffix: "" },
-    { label: "Spotify Followers", value: 10, suffix: "" },
-    { label: "Published Tracks", value: 10, suffix: "+" },
-    { label: "Albums Released", value: 6, suffix: "" }
+    { label: "Monthly Listeners", value: 4, suffix: "", Icon: FaUsers },
+    { label: "Spotify Followers", value: 10, suffix: "", Icon: FaSpotify },
+    { label: "Published Tracks", value: 10, suffix: "+", Icon: FaMusic },
+    { label: "Albums Released", value: 6, suffix: "", Icon: FaCompactDisc }
   ];
 
   const sectionRef = useRef<HTMLDivElement>(null);
   const headingRef = useRef<HTMLHeadingElement>(null);
   const statCardRefs = useRef<(HTMLDivElement | null)[]>([]);
   const trackCardRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const platformCardsRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    // Capture ref values for cleanup to avoid stale `.current` warnings
     const sectionEl = sectionRef.current;
     const headingEl = headingRef.current;
     const statEls = statCardRefs.current.slice();
     const trackEls = trackCardRefs.current.slice();
+    const platformEl = platformCardsRef.current;
 
-    // Optimized delay to ensure DOM elements are fully rendered after lazy loading
     const timer = setTimeout(() => {
-      // Section entrance animation - using ScrollTrigger for smooth entrance
       animations.fadeIn(sectionRef.current, {
         duration: 1.2,
         y: 20,
         scrollTrigger: true,
       });
 
-      // Heading animation - with scroll trigger for better visual impact
       animations.textReveal(headingRef.current, {
         duration: 1.5,
         delay: 0.2,
         scrollTrigger: true,
       });
 
-      // Staggered stat cards animation - with scroll trigger for better UX
       animations.staggerFadeIn(statCardRefs.current, {
         duration: 0.8,
         stagger: 0.1,
@@ -84,7 +79,6 @@ function MusicSection() {
         scrollTrigger: true,
       });
 
-      // Staggered track cards animation - with scroll trigger for consistency
       animations.staggerFadeIn(trackCardRefs.current, {
         duration: 0.8,
         stagger: 0.15,
@@ -92,23 +86,21 @@ function MusicSection() {
         y: 40,
         scrollTrigger: true,
       });
-    }, 150); // Optimized delay for DOM readiness
+
+      if (platformCardsRef.current) {
+        animations.fadeIn(platformCardsRef.current, {
+          duration: 0.8,
+          delay: 0.5,
+          y: 30,
+          scrollTrigger: true,
+        });
+      }
+    }, 150);
 
     return () => {
       clearTimeout(timer);
-      // Targeted cleanup for this section only
-      killScrollTriggersFor([
-        sectionEl,
-        headingEl,
-        statEls,
-        trackEls,
-      ]);
-      killTweensFor([
-        sectionEl,
-        headingEl,
-        statEls,
-        trackEls,
-      ]);
+      killScrollTriggersFor([sectionEl, headingEl, statEls, trackEls, platformEl]);
+      killTweensFor([sectionEl, headingEl, statEls, trackEls, platformEl]);
     };
   }, []);
 
@@ -116,45 +108,48 @@ function MusicSection() {
     <div
       ref={sectionRef}
       aria-labelledby="music-heading"
-      className="relative py-6 px-8"
+      className="relative overflow-hidden min-h-[110vh] py-6 px-12 min-w-full"
     >
-      {/* Background Elements */}
-      <div className="pointer-events-none absolute -inset-x-16 -top-16 -bottom-0 md:-inset-x-24 md:-top-24 md:-bottom-0">
+      {/* Background - Matching DevelopmentSection pattern with gradient overlay */}
+      <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden" aria-hidden="true">
+        {/* Animated gradient orbs - using emerald theme instead of purple */}
         <div className="absolute inset-0 opacity-30">
-          <div className="absolute top-1/4 right-1/4 w-96 h-96 bg-purple-500 rounded-full mix-blend-multiply filter blur-xl opacity-20 animate-pulse"></div>
-          <div className="absolute bottom-1/4 left-1/4 w-96 h-96 bg-blue-500 rounded-full mix-blend-multiply filter blur-xl opacity-20 animate-pulse animation-delay-2000"></div>
-          <div className="absolute top-3/4 left-1/2 w-96 h-96 bg-indigo-500 rounded-full mix-blend-multiply filter blur-xl opacity-20 animate-pulse animation-delay-4000"></div>
+          <div className="absolute top-1/4 right-1/4 w-96 h-96 bg-emerald-500 rounded-full mix-blend-multiply filter blur-xl opacity-20 animate-pulse"></div>
+          <div className="absolute bottom-1/4 left-1/4 w-96 h-96 bg-cyan-500 rounded-full mix-blend-multiply filter blur-xl opacity-20 animate-pulse animation-delay-2000"></div>
+          <div className="absolute top-3/4 left-1/2 w-96 h-96 bg-teal-500 rounded-full mix-blend-multiply filter blur-xl opacity-20 animate-pulse animation-delay-4000"></div>
         </div>
+        {/* Dark overlay for consistency */}
+        <div className="absolute inset-0 bg-gradient-to-b from-slate-900/90 via-slate-900/95 to-slate-900" />
       </div>
 
       <div className="container-responsive relative z-10 section-content-container">
+        {/* Section Header - Matching DevelopmentSection pattern */}
         <header className="text-center mb-16">
           <div className="inline-flex items-center gap-3 mb-6 px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full border border-white/20">
-            <span className="w-2 h-2 bg-purple-400 rounded-full animate-pulse"></span>
-            <span className="text-purple-200 font-medium">Music & Audio</span>
+            <FaHeadphones className="w-5 h-5 text-emerald-300" />
+            <span className="text-emerald-200 font-medium">Music & Audio</span>
           </div>
 
-          <h1
+          <h2
             ref={headingRef}
             id="music-heading"
             className="text-4xl md:text-6xl lg:text-7xl font-bold mb-6 text-white"
             tabIndex={-1}
           >
-            <span className="gradient-text">Music Production</span>
-            
-            <span className="text-gray-300 text-3xl md:text-4xl lg:text-5xl font-light"> & Audio Projects</span>
-          </h1>
+            <span className="gradient-text">Audio Production</span>
+          </h2>
 
           <p className="text-xl md:text-2xl text-gray-300 mb-12 max-w-3xl mx-auto leading-relaxed">
             Electronic music production featuring synth compositions, modular synthesis, and experimental audio design
           </p>
-          {/* Streaming Platforms */}
+
+          {/* Streaming Platform Buttons - Updated styling */}
           <div className="flex flex-col sm:flex-row gap-4 justify-center mb-16">
             <a
               href="https://open.spotify.com/artist/4cHJRNFfmZcx44gkmTr8mH?si=p__McSMTTbyGI3AQeVi52A"
               target="_blank"
               rel="noopener noreferrer"
-              className="group inline-flex items-center gap-3 px-8 py-4 rounded-xl bg-green-600 hover:bg-green-700 text-white font-semibold shadow-lg hover:shadow-green-500/25 transition-all duration-300 transform hover:scale-105"
+              className="group inline-flex items-center gap-3 px-8 py-4 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white font-semibold shadow-lg hover:shadow-emerald-500/25 transition-all duration-300 transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-slate-900"
               aria-label="Listen to my music on Spotify"
             >
               <FaSpotify className="w-6 h-6" />
@@ -165,7 +160,7 @@ function MusicSection() {
               href="https://soundcloud.com/user-228826128"
               target="_blank"
               rel="noopener noreferrer"
-              className="group inline-flex items-center gap-3 px-8 py-4 rounded-xl bg-orange-600 hover:bg-orange-700 text-white font-semibold shadow-lg hover:shadow-orange-500/25 transition-all duration-300 transform hover:scale-105"
+              className="group inline-flex items-center gap-3 px-8 py-4 rounded-xl glass-effect border border-white/20 hover:border-emerald-400/50 text-white font-semibold shadow-lg hover:shadow-emerald-500/10 transition-all duration-300 transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-slate-900"
               aria-label="Listen to my music on SoundCloud"
             >
               <FaSoundcloud className="w-6 h-6" />
@@ -173,97 +168,106 @@ function MusicSection() {
               <span className="w-4 h-4 group-hover:translate-x-1 transition-transform" aria-hidden="true">→</span>
             </a>
           </div>
-          {/* Audio Stats */}
+
+          {/* Audio Stats - Using glass effect cards */}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-16" role="region" aria-label="Audio engineering statistics">
-            {audioStats.map((stat, index) => {
-              const Icon =
-                stat.label === 'Monthly Listeners' ? FaUsers :
-                stat.label === 'Spotify Followers' ? FaSpotify :
-                stat.label === 'Published Tracks' ? FaMusic :
-                FaCompactDisc;
-              return (
-                <div key={index} ref={el => (statCardRefs.current[index] = el)}>
-                  <MusicStatCard
-                    label={stat.label}
-                    value={stat.value}
-                    suffix={stat.suffix}
-                    Icon={Icon}
-                    delayMs={index * 300}
-                  />
-                </div>
-              );
-            })}
+            {audioStats.map((stat, index) => (
+              <div key={index} ref={el => (statCardRefs.current[index] = el)}>
+                <MusicStatCard
+                  label={stat.label}
+                  value={stat.value}
+                  suffix={stat.suffix}
+                  Icon={stat.Icon}
+                  delayMs={index * 300}
+                />
+              </div>
+            ))}
           </div>
         </header>
-        <Typography type="h2" id="audio-projects-heading" variant="h3" className="mb-6 text-center sm:text-left">
-          <span className="gradient-text">Featured Audio Projects</span>
-        </Typography>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12" role="region" aria-labelledby="audio-projects-heading">
-          {audioProjects.map((project, index) => (
-            <InteractiveCard
-              key={index}
-              tiltEffect={true}
-              scaleOnHover={true}
-              shadowIntensity="medium"
-              className="track-card-wrapper"
-            >
-              <div
-                ref={(el) => (trackCardRefs.current[index] = el)}
-                className="h-full focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                tabIndex={0}
+
+        {/* Featured Audio Projects Section */}
+        <section className="mb-16">
+          <h3 id="audio-projects-heading" className="text-2xl md:text-3xl font-bold mb-8 text-center sm:text-left">
+            <span className="gradient-text">Featured Audio Projects</span>
+          </h3>
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" role="region" aria-labelledby="audio-projects-heading">
+            {audioProjects.map((project, index) => (
+              <InteractiveCard
+                key={index}
+                tiltEffect={true}
+                scaleOnHover={true}
+                shadowIntensity="medium"
+                className="h-full"
               >
-                <TrackCard track={project} />
-              </div>
-            </InteractiveCard>
-          ))}
-        </div>
-        
-        <Typography type="h4" id="music-links-heading" className="mb-2 text-center sm:text-left">
-          <span className="gradient-text">Listen to My Music</span>
-        </Typography>
-        <Typography type="p" className="mb-4 max-w-2xl mx-auto text-neutral-200 sm:text-base text-sm">
-          Stream my electronic music, synth compositions, and experimental audio across platforms
-        </Typography>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6" role="region" aria-labelledby="music-links-heading">
-          {/* Spotify Card */}
-          <div className="music-platform-card spotify-card bg-green-600 hover:bg-green-700 rounded-lg shadow-md p-6 flex flex-col items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-green-400 transition" tabIndex={0}>
+                <div
+                  ref={(el) => (trackCardRefs.current[index] = el)}
+                  className="h-full focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+                  tabIndex={0}
+                >
+                  <TrackCard track={project} />
+                </div>
+              </InteractiveCard>
+            ))}
+          </div>
+        </section>
+
+        {/* Platform Links Section */}
+        <section ref={platformCardsRef}>
+          <h3 id="music-links-heading" className="text-2xl md:text-3xl font-bold mb-4 text-center sm:text-left">
+            <span className="gradient-text">Stream My Music</span>
+          </h3>
+          <p className="text-gray-400 mb-8 max-w-2xl sm:text-base text-sm text-center sm:text-left">
+            Stream my electronic music, synth compositions, and experimental audio across platforms
+          </p>
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6" role="region" aria-labelledby="music-links-heading">
+            {/* Spotify Platform Card */}
             <a
               href="https://open.spotify.com/artist/4cHJRNFfmZcx44gkmTr8mH?si=p__McSMTTbyGI3AQeVi52A"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex flex-col items-center gap-2 text-white font-semibold hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-green-400"
+              className="group glass-effect rounded-2xl p-8 border border-white/10 hover:border-emerald-400/50 transition-all duration-300 hover:shadow-xl hover:shadow-emerald-500/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-slate-900"
               aria-label="Listen to my music on Spotify"
             >
-              <FaSpotify className="w-8 h-8 mb-2" />
-              <span className="text-lg">Spotify</span>
-              <span className="text-sm">Albums, singles, and synth music releases</span>
-              <span className="inline-block mt-2 text-base font-bold">Listen Now →</span>
+              <div className="flex flex-col items-center text-center">
+                <div className="w-16 h-16 rounded-full bg-emerald-500/20 flex items-center justify-center mb-4 group-hover:bg-emerald-500/30 transition-colors">
+                  <FaSpotify className="w-8 h-8 text-emerald-400" />
+                </div>
+                <h4 className="text-xl font-semibold text-white mb-2">Spotify</h4>
+                <p className="text-gray-400 text-sm mb-4">Albums, singles, and synth music releases</p>
+                <span className="inline-flex items-center gap-2 text-emerald-400 font-medium group-hover:gap-3 transition-all">
+                  Listen Now
+                  <span aria-hidden="true">→</span>
+                </span>
+              </div>
             </a>
-          </div>
-          {/* SoundCloud Card */}
-          <div className="music-platform-card soundcloud-card bg-orange-600 hover:bg-orange-700 rounded-lg shadow-md p-6 flex flex-col items-center focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-300 transition" tabIndex={0}>
+
+            {/* SoundCloud Platform Card */}
             <a
               href="https://soundcloud.com/user-228826128"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex flex-col items-center gap-2 text-white font-semibold hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-300"
+              className="group glass-effect rounded-2xl p-8 border border-white/10 hover:border-emerald-400/50 transition-all duration-300 hover:shadow-xl hover:shadow-emerald-500/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-slate-900"
               aria-label="Visit my SoundCloud profile"
             >
-              <FaSoundcloud className="w-8 h-8 mb-2" />
-              <span className="text-lg">SoundCloud</span>
-              <span className="text-sm">Original music and audio experiments</span>
-              <span className="inline-block mt-2 text-base font-bold">Explore →</span>
+              <div className="flex flex-col items-center text-center">
+                <div className="w-16 h-16 rounded-full bg-emerald-500/20 flex items-center justify-center mb-4 group-hover:bg-emerald-500/30 transition-colors">
+                  <FaSoundcloud className="w-8 h-8 text-emerald-400" />
+                </div>
+                <h4 className="text-xl font-semibold text-white mb-2">SoundCloud</h4>
+                <p className="text-gray-400 text-sm mb-4">Original music and audio experiments</p>
+                <span className="inline-flex items-center gap-2 text-emerald-400 font-medium group-hover:gap-3 transition-all">
+                  Explore
+                  <span aria-hidden="true">→</span>
+                </span>
+              </div>
             </a>
           </div>
-        </div>
+        </section>
       </div>
     </div>
   );
 }
 
 export default MusicSection;
-
-
-
-
-

--- a/src/components/MusicStatCard.tsx
+++ b/src/components/MusicStatCard.tsx
@@ -1,4 +1,3 @@
-import { Card, CardBody, Typography } from '@material-tailwind/react';
 import { IconType } from 'react-icons';
 import AnimatedCounter from './AnimatedCounter';
 
@@ -20,22 +19,36 @@ export default function MusicStatCard({
   className = ''
 }: MusicStatCardProps) {
   return (
-    <Card className={`relative glass-effect bg-white/10 dark:bg-white/5 backdrop-blur-md border border-white/15 hover:border-white/30 shadow-lg hover:shadow-xl transition-all rounded-2xl overflow-hidden ${className}`}>
-      <div className="pointer-events-none absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300" aria-hidden="true" />
-      <CardBody className="p-6 text-center">
+    <div 
+      className={`
+        relative glass-effect bg-white/5 backdrop-blur-md 
+        border border-white/10 hover:border-emerald-400/50 
+        shadow-lg hover:shadow-xl hover:shadow-emerald-500/10 
+        transition-all duration-300 rounded-xl overflow-hidden 
+        ${className}
+      `}
+    >
+      {/* Hover gradient overlay */}
+      <div 
+        className="pointer-events-none absolute inset-0 opacity-0 hover:opacity-100 bg-gradient-to-br from-emerald-500/5 to-transparent transition-opacity duration-300" 
+        aria-hidden="true" 
+      />
+      
+      <div className="p-6 text-center relative z-10">
         {Icon && (
-          <div className="mx-auto mb-3 flex items-center justify-center w-10 h-10 rounded-full bg-gradient-to-br from-indigo-500/30 to-purple-500/30 text-white">
-            {Icon && <Icon className="w-5 h-5" aria-hidden="true" />}
+          <div className="mx-auto mb-3 flex items-center justify-center w-12 h-12 rounded-full bg-emerald-500/20 text-emerald-400 transition-colors duration-300">
+            <Icon className="w-5 h-5" aria-hidden="true" />
           </div>
         )}
-        <Typography type="h3" className="mb-1 text-white font-bold text-2xl md:text-3xl">
+        
+        <div className="text-2xl md:text-3xl font-bold text-white mb-1">
           <AnimatedCounter end={value} suffix={suffix} duration={2500} delay={delayMs} />
-        </Typography>
-        <Typography type="p" className="text-xs tracking-wider uppercase text-gray-300">
+        </div>
+        
+        <p className="text-xs tracking-wider uppercase text-gray-400">
           {label}
-        </Typography>
-      </CardBody>
-    </Card>
+        </p>
+      </div>
+    </div>
   );
 }
-

--- a/src/components/TechFilters.tsx
+++ b/src/components/TechFilters.tsx
@@ -1,0 +1,168 @@
+import { useMemo } from 'react';
+import { FaTerminal, FaJava } from 'react-icons/fa';
+import { 
+  SiTypescript, SiJavascript, SiPython, SiVuedotjs, SiHtml5, SiCss3, SiNodedotjs, 
+  SiC, SiCplusplus, SiMarkdown, SiPowers, 
+  SiVim, SiGnu, SiGo, SiRust, SiDart, 
+  SiKotlin, SiSwift, SiZig, SiJulia, 
+  SiRuby, SiPhp, SiScala, SiElixir, 
+  SiHaskell, SiSolidity, SiSvelte, 
+  SiAstro, SiNextdotjs, SiRemix, 
+  SiFlutter, SiReact, SiAngular, 
+  SiDocker, SiTerraform, SiGraphql, 
+  SiMysql, SiPostgresql, SiMongodb, SiRedis, 
+  SiFirebase, SiAmazonwebservices, 
+} from 'react-icons/si';
+import type { IconType } from 'react-icons';
+
+// Icon map for techs (same as GitHubProjects)
+const TECH_ICON_MAP: Array<{
+  match: (t: string) => boolean;
+  icon: IconType;
+  color: string;
+  label: string;
+}> = [
+  { match: (t: string) => t === 'go' || t === 'golang', icon: SiGo, color: 'text-cyan-400', label: 'Go' },
+  { match: (t: string) => t === 'rust', icon: SiRust, color: 'text-orange-400', label: 'Rust' },
+  { match: (t: string) => t === 'dart', icon: SiDart, color: 'text-sky-400', label: 'Dart' },
+  { match: (t: string) => t === 'kotlin', icon: SiKotlin, color: 'text-purple-400', label: 'Kotlin' },
+  { match: (t: string) => t === 'swift', icon: SiSwift, color: 'text-orange-400', label: 'Swift' },
+  { match: (t: string) => t === 'zig', icon: SiZig, color: 'text-yellow-400', label: 'Zig' },
+  { match: (t: string) => t === 'julia', icon: SiJulia, color: 'text-fuchsia-400', label: 'Julia' },
+  { match: (t: string) => t === 'ruby', icon: SiRuby, color: 'text-red-400', label: 'Ruby' },
+  { match: (t: string) => t === 'php', icon: SiPhp, color: 'text-indigo-400', label: 'PHP' },
+  { match: (t: string) => t === 'scala', icon: SiScala, color: 'text-red-400', label: 'Scala' },
+  { match: (t: string) => t === 'elixir', icon: SiElixir, color: 'text-purple-400', label: 'Elixir' },
+  { match: (t: string) => t === 'haskell', icon: SiHaskell, color: 'text-violet-400', label: 'Haskell' },
+  { match: (t: string) => t === 'solidity', icon: SiSolidity, color: 'text-gray-400', label: 'Solidity' },
+  { match: (t: string) => t === 'svelte', icon: SiSvelte, color: 'text-orange-400', label: 'Svelte' },
+  { match: (t: string) => t === 'astro', icon: SiAstro, color: 'text-indigo-400', label: 'Astro' },
+  { match: (t: string) => t === 'nextjs' || t === 'next', icon: SiNextdotjs, color: 'text-white', label: 'Next.js' },
+  { match: (t: string) => t === 'remix', icon: SiRemix, color: 'text-blue-400', label: 'Remix' },
+  { match: (t: string) => t === 'flutter', icon: SiFlutter, color: 'text-sky-400', label: 'Flutter' },
+  { match: (t: string) => t === 'react', icon: SiReact, color: 'text-cyan-400', label: 'React' },
+  { match: (t: string) => t === 'angular', icon: SiAngular, color: 'text-red-400', label: 'Angular' },
+  { match: (t: string) => t === 'docker', icon: SiDocker, color: 'text-blue-400', label: 'Docker' },
+  { match: (t: string) => t === 'terraform', icon: SiTerraform, color: 'text-purple-400', label: 'Terraform' },
+  { match: (t: string) => t === 'graphql', icon: SiGraphql, color: 'text-pink-400', label: 'GraphQL' },
+  { match: (t: string) => t === 'mysql', icon: SiMysql, color: 'text-yellow-400', label: 'MySQL' },
+  { match: (t: string) => t === 'postgresql' || t === 'postgres', icon: SiPostgresql, color: 'text-blue-400', label: 'PostgreSQL' },
+  { match: (t: string) => t === 'mongodb', icon: SiMongodb, color: 'text-green-400', label: 'MongoDB' },
+  { match: (t: string) => t === 'redis', icon: SiRedis, color: 'text-red-400', label: 'Redis' },
+  { match: (t: string) => t === 'firebase', icon: SiFirebase, color: 'text-yellow-400', label: 'Firebase' },
+  { match: (t: string) => t === 'aws' || t === 'amazonwebservices', icon: SiAmazonwebservices, color: 'text-yellow-400', label: 'AWS' },
+  { match: (t: string) => t.includes('typescript'), icon: SiTypescript, color: 'text-blue-400', label: 'TypeScript' },
+  { match: (t: string) => t.includes('javascript'), icon: SiJavascript, color: 'text-amber-400', label: 'JavaScript' },
+  { match: (t: string) => t.includes('python'), icon: SiPython, color: 'text-purple-400', label: 'Python' },
+  { match: (t: string) => t.includes('vue'), icon: SiVuedotjs, color: 'text-green-400', label: 'Vue' },
+  { match: (t: string) => t.includes('html'), icon: SiHtml5, color: 'text-pink-400', label: 'HTML' },
+  { match: (t: string) => t.includes('css'), icon: SiCss3, color: 'text-indigo-400', label: 'CSS' },
+  { match: (t: string) => t.includes('node'), icon: SiNodedotjs, color: 'text-lime-400', label: 'Node.js' },
+  { match: (t: string) => ['bash', 'shell', 'sh'].includes(t), icon: FaTerminal, color: 'text-gray-400', label: 'Shell' },
+  { match: (t: string) => t === 'powershell', icon: SiPowers, color: 'text-blue-400', label: 'PowerShell' },
+  { match: (t: string) => t === 'c', icon: SiC, color: 'text-cyan-400', label: 'C' },
+  { match: (t: string) => t === 'cpp' || t === 'c++', icon: SiCplusplus, color: 'text-blue-400', label: 'C++' },
+  { match: (t: string) => t === 'java', icon: FaJava, color: 'text-orange-400', label: 'Java' },
+  { match: (t: string) => t === 'md' || t === 'markdown', icon: SiMarkdown, color: 'text-gray-400', label: 'Markdown' },
+  { match: (t: string) => t === 'vim' || t === 'vimscript', icon: SiVim, color: 'text-green-400', label: 'Vim Script' },
+  { match: (t: string) => t === 'makefile' || t === 'make' || t === 'cmake', icon: SiGnu, color: 'text-yellow-400', label: 'Make' },
+];
+
+const normalize = (t?: string) => (t || '').toLowerCase().replace(/[^a-z0-9+]/g, '');
+
+function getTechInfo(techRaw?: string): { icon: IconType; color: string; label: string } {
+  const tech = normalize(techRaw);
+  for (const entry of TECH_ICON_MAP) {
+    if (entry.match(tech)) {
+      return { icon: entry.icon, color: entry.color, label: entry.label };
+    }
+  }
+  return { icon: FaTerminal, color: 'text-gray-400', label: techRaw || 'Unknown' };
+}
+
+interface TechFiltersProps {
+  technologies: string[];
+  selectedTech: string | null;
+  onSelectTech: (tech: string | null) => void;
+  projectCounts: Record<string, number>;
+}
+
+export default function TechFilters({ 
+  technologies, 
+  selectedTech, 
+  onSelectTech,
+  projectCounts 
+}: TechFiltersProps) {
+  // Get unique technologies with their icons
+  const techItems = useMemo(() => {
+    return technologies
+      .map(tech => {
+        const normalized = normalize(tech);
+        const info = getTechInfo(tech);
+        return {
+          raw: tech,
+          normalized,
+          ...info,
+          count: projectCounts[normalized] || 0
+        };
+      })
+      .filter(item => item.count > 0)
+      .sort((a, b) => b.count - a.count);
+  }, [technologies, projectCounts]);
+
+  if (techItems.length === 0) return null;
+
+  return (
+    <div className="mb-8">
+      <h3 className="text-sm font-medium text-gray-400 mb-3 uppercase tracking-wider">
+        Filter by Technology
+      </h3>
+      <div className="flex flex-wrap gap-2">
+        {/* "All" filter button */}
+        <button
+          onClick={() => onSelectTech(null)}
+          className={`
+            inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium
+            transition-all duration-200 border
+            ${selectedTech === null
+              ? 'bg-emerald-500/20 border-emerald-400/50 text-emerald-300 ring-2 ring-emerald-500/30'
+              : 'bg-white/5 border-white/20 text-gray-300 hover:bg-white/10 hover:border-white/30'
+            }
+          `}
+          aria-pressed={selectedTech === null}
+        >
+          <span className="w-4 h-4 flex items-center justify-center text-xs">∞</span>
+          All
+          <span className="ml-1 px-1.5 py-0.5 text-xs rounded-full bg-white/10">
+            {Object.values(projectCounts).reduce((sum, n) => sum + n, 0) / (techItems.length || 1) > 1 
+              ? techItems.length 
+              : Object.keys(projectCounts).length}
+          </span>
+        </button>
+
+        {/* Technology filter buttons */}
+        {techItems.map(({ normalized, icon: Icon, color, label, count }) => (
+          <button
+            key={normalized}
+            onClick={() => onSelectTech(selectedTech === normalized ? null : normalized)}
+            className={`
+              inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium
+              transition-all duration-200 border
+              ${selectedTech === normalized
+                ? `bg-white/15 border-white/40 ${color} ring-2 ring-white/20`
+                : 'bg-white/5 border-white/20 text-gray-300 hover:bg-white/10 hover:border-white/30'
+              }
+            `}
+            aria-pressed={selectedTech === normalized}
+          >
+            <Icon className={`w-4 h-4 ${selectedTech === normalized ? color : ''}`} />
+            {label}
+            <span className="ml-1 px-1.5 py-0.5 text-xs rounded-full bg-white/10">
+              {count}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TrackCard.tsx
+++ b/src/components/TrackCard.tsx
@@ -1,6 +1,4 @@
-import { Card, CardBody, CardHeader, CardFooter, Typography, Chip, Button } from "@material-tailwind/react";
 import { FaClock, FaPlay, FaSoundcloud } from "react-icons/fa";
-
 
 interface Track {
   title: string;
@@ -16,10 +14,11 @@ interface TrackCardProps {
 
 function getGradientForGenre(genre: string): string {
   const g = genre.toLowerCase();
-  if (g.includes("ambient")) return "from-indigo-500 via-blue-500 to-purple-600"; // cool blues/purples
-  if (g.includes("modular") || g.includes("synthesis")) return "from-teal-400 via-emerald-500 to-cyan-500"; // techy greens/cyans
-  if (g.includes("garage")) return "from-orange-500 via-rose-500 to-red-600"; // warm oranges/reds
-  return "from-slate-600 via-indigo-600 to-purple-700"; // default
+  // Using emerald-based gradients to match site theme
+  if (g.includes("ambient")) return "from-emerald-600 via-teal-600 to-cyan-600";
+  if (g.includes("modular") || g.includes("synthesis")) return "from-teal-500 via-emerald-500 to-green-600";
+  if (g.includes("garage")) return "from-emerald-500 via-green-500 to-lime-600";
+  return "from-slate-600 via-emerald-600 to-teal-600";
 }
 
 function TrackCard({ track }: TrackCardProps) {
@@ -27,67 +26,74 @@ function TrackCard({ track }: TrackCardProps) {
   const gradient = getGradientForGenre(track.genre);
 
   return (
-    <Card className="h-full bg-white/80 dark:bg-neutral-900 border border-white/10 shadow-lg" role="article" aria-labelledby={trackId}>
-      <CardHeader
-        floated={undefined}
-        className={`relative grid place-content-center h-28 bg-gradient-to-r ${gradient} rounded-b-none text-white`}
+    <article 
+      className="h-full glass-effect bg-white/5 backdrop-blur-md border border-white/10 hover:border-emerald-400/50 rounded-xl overflow-hidden transition-all duration-300" 
+      role="article" 
+      aria-labelledby={trackId}
+    >
+      {/* Album Art Header */}
+      <header
+        className={`relative grid place-content-center h-28 bg-gradient-to-r ${gradient}`}
       >
-        <FaSoundcloud className="w-16 h-16" aria-hidden="true" />
-      </CardHeader>
+        <FaSoundcloud className="w-14 h-14 text-white/80" aria-hidden="true" />
+        {/* Decorative overlay */}
+        <div className="absolute inset-0 bg-black/10" aria-hidden="true" />
+      </header>
 
-      <CardBody className="p-5">
-        <Typography type="h5" className="mb-2 text-neutral-900 dark:text-white" id={trackId}>
+      {/* Card Content */}
+      <div className="p-5">
+        <h4 className="text-lg font-semibold text-white mb-3" id={trackId}>
           {track.title}
-        </Typography>
+        </h4>
 
         <div className="flex items-center flex-wrap gap-2 mb-3">
-          <Chip size="sm" className="bg-indigo-100 text-indigo-700 dark:bg-indigo-900/50 dark:text-indigo-200">{track.genre}</Chip>
-          <span className="inline-flex items-center gap-1 text-sm text-neutral-700 dark:text-neutral-300" aria-label="Year or duration">
-            <FaClock className="w-4 h-4" aria-hidden="true" />
+          {/* Genre Tag - Using emerald theme */}
+          <span className="px-3 py-1 bg-emerald-600/20 text-emerald-300 text-xs rounded-full border border-emerald-500/30">
+            {track.genre}
+          </span>
+          {/* Duration/Year */}
+          <span 
+            className="inline-flex items-center gap-1 text-sm text-gray-400" 
+            aria-label="Year or duration"
+          >
+            <FaClock className="w-3.5 h-3.5" aria-hidden="true" />
             {track.duration}
           </span>
         </div>
 
         {track.description && (
-          <Typography type="p" className="text-sm leading-relaxed text-neutral-700 dark:text-neutral-300 line-clamp-4">
+          <p className="text-sm leading-relaxed text-gray-400 line-clamp-3 mb-4">
             {track.description}
-          </Typography>
+          </p>
         )}
-      </CardBody>
+      </div>
 
-      <CardFooter className="pt-0">
+      {/* Card Footer */}
+      <div className="px-5 pb-5 pt-0">
         {track.soundCloudUrl ? (
-          <Button
-            size="md"
-            color="primary"
-            className="w-full flex items-center justify-center gap-2"
-            variant="solid"
-            as="a"
+          <a
             href={track.soundCloudUrl}
             target="_blank"
             rel="noopener noreferrer"
-            aria-label={`Open Soundcloud: ${track.title}`}
+            className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-slate-900"
+            aria-label={`Preview ${track.title} on SoundCloud`}
           >
-            <FaPlay className="w-4 h-4" aria-hidden="true" />
-            Preview on Soundcloud
-          </Button>
+            <FaPlay className="w-3.5 h-3.5" aria-hidden="true" />
+            Preview on SoundCloud
+          </a>
         ) : (
-          <Button
-            size="md"
-            color="primary"
-            className="w-full flex items-center justify-center gap-2"
-            variant="solid"
+          <button
             disabled
+            className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-lg bg-gray-700/50 text-gray-500 font-medium cursor-not-allowed"
             aria-label={`Preview unavailable for ${track.title}`}
           >
-            <FaPlay className="w-4 h-4" aria-hidden="true" />
+            <FaPlay className="w-3.5 h-3.5" aria-hidden="true" />
             Preview Unavailable
-          </Button>
+          </button>
         )}
-      </CardFooter>
-    </Card>
+      </div>
+    </article>
   );
 }
 
 export default TrackCard;
-


### PR DESCRIPTION
- Redesign ContactSection with cassette tape and vinyl record visuals
- Add LanguageDistribution and TechFilters components for project filtering
- Update MusicSection, MusicStatCard, and TrackCard to emerald color theme
- Replace Material Tailwind components with plain HTML/Tailwind CSS
- Add legal pages (cookies, privacy, terms)
- Fix footer GitHub and LinkedIn URLs
- Improve background video sizing in DevelopmentSection

## Summary by Sourcery

Redesign the contact and music sections with a cohesive retro/emerald visual theme, introduce technology-based filtering for GitHub projects, and add standalone legal policy pages.

New Features:
- Add language distribution visualization and technology filter controls for GitHub projects in the development section.
- Introduce cassette tape and vinyl record–styled contact UI with updated link treatments and animations.
- Add static legal pages for privacy policy, terms of service, and cookie policy.

Bug Fixes:
- Correct footer GitHub and LinkedIn profile URLs.

Enhancements:
- Restyle the music section, stat cards, and track cards to use an emerald-themed glassmorphism design and improved accessibility.
- Improve the development section background video sizing to better cover the viewport and align with other sections.
- Refine GitHub projects layout to better handle filtering and small result sets, including empty states.

Documentation:
- Add user-facing HTML pages documenting privacy policy, terms of service, and cookie policy.